### PR TITLE
Fix datatable

### DIFF
--- a/backend/main/views_with_api.py
+++ b/backend/main/views_with_api.py
@@ -330,7 +330,7 @@ def get_step_table(request):
 
         run = Run(run_name)
 
-        json_data = [{}]
+        json_data = []
         
         if run.current_step is not None:
             for dataframe in dataframes:

--- a/backend/main/views_with_api.py
+++ b/backend/main/views_with_api.py
@@ -19,6 +19,7 @@ from backend.main.views_with_api_helper import get_step, get_displayed_steps, pa
 
 database_metadata_path = EXTERNAL_DATA_PATH / "internal" / "metadata" / "uniprot.json"
 
+dataframes = ["protein_df", "metadata_df", "peptide_df"]
 
 def run_information_list(request):
     run_info = get_available_run_info()
@@ -328,15 +329,20 @@ def get_step_table(request):
         run_name = data.get("run_name")
 
         run = Run(run_name)
+
+        json_data = [{}]
         
         if run.current_step is not None:
-            if "protein_df" in run.current_outputs:
-                data = run.current_outputs["protein_df"]
-                data["id"] = data.index
-                cleaned_data = data.replace(np.nan, None)
-                json_data = cleaned_data.to_dict(orient="records") # TODO #49 this should be refactored to be stored somewhere and not be calculated on every get_step_table (can take a few seconds)
-            else:
-                json_data = [{}]
+            for dataframe in dataframes:
+                if dataframe in run.current_outputs:
+                    data = run.current_outputs[dataframe]
+                    print(type(data))
+                    if type(data) == str:
+                        print(run.current_step.display_name)
+                    data["id"] = data.index
+                    cleaned_data = data.replace(np.nan, None)
+                    json_data = cleaned_data.to_dict(orient="records") # TODO #49 this should be refactored to be stored somewhere and not be calculated on every get_step_table (can take a few seconds)
+                    break
 
         return JsonResponse({"success": True, "message": "Got the table for the step", "data": json_data}, safe=False)
     else:

--- a/backend/main/views_with_api.py
+++ b/backend/main/views_with_api.py
@@ -336,9 +336,6 @@ def get_step_table(request):
             for dataframe in dataframes:
                 if dataframe in run.current_outputs:
                     data = run.current_outputs[dataframe]
-                    print(type(data))
-                    if type(data) == str:
-                        print(run.current_step.display_name)
                     data["id"] = data.index
                     cleaned_data = data.replace(np.nan, None)
                     json_data = cleaned_data.to_dict(orient="records") # TODO #49 this should be refactored to be stored somewhere and not be calculated on every get_step_table (can take a few seconds)

--- a/backend/protzilla/steps.py
+++ b/backend/protzilla/steps.py
@@ -744,15 +744,10 @@ class StepManager:
             )
 
         if self.df_mode == "disk":
-                # TODO maybe this doesnt really need to be written to disk anymore,
-                # as it is preceeded by a calculation, after which everything is written to
-                # disk anyway. Better would be if it would just replace the dfs with their respective paths
-            self.current_step.output = Output(
-                self.disk_operator._write_output(
-                    instance_identifier=self.current_step.instance_identifier,
-                    output=self.current_step.output,
-                )
-        )
+            self.disk_operator._write_output(
+                instance_identifier=self.current_step.instance_identifier,
+                output=self.current_step.output,
+            )
         step = self.all_steps_in_section(section)[step_index]
         new_step_index = self.all_steps.index(step)
         self.current_step_index = new_step_index

--- a/frontend/src/components/data-table/data-table.tsx
+++ b/frontend/src/components/data-table/data-table.tsx
@@ -4,7 +4,6 @@ import {
   GridColDef,
   GridColumnVisibilityModel,
   GridPaginationModel,
-  GridRowsProp,
 } from "@mui/x-data-grid";
 import React, { useMemo, useState } from "react";
 
@@ -12,7 +11,6 @@ import { DataTableProps } from "./data-table.props";
 import { baseTheme, getMuiTheme } from "../../theme";
 
 export const DataTable: React.FC<DataTableProps> = ({ data, pageSize, pageSizeOptions }) => {
-  const [rows] = useState<GridRowsProp>(data);
   const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
     page: 0,
     pageSize: pageSize ?? 10,
@@ -46,7 +44,7 @@ export const DataTable: React.FC<DataTableProps> = ({ data, pageSize, pageSizeOp
   return (
     <ThemeProvider theme={theme}>
       <DataGrid
-        rows={rows}
+        rows={data}
         columns={columns}
         columnVisibilityModel={columnVisibilityModel}
         onColumnVisibilityModelChange={(newModel) => {

--- a/frontend/src/screens/run-screen.tsx
+++ b/frontend/src/screens/run-screen.tsx
@@ -155,7 +155,11 @@ export const RunScreen: React.FC = () => {
 
   const tableComponent = (
     <StyledTableContainer>
-      <DataTable data={tableData} />
+      {tableData.length > 0 ? (
+        <DataTable data={tableData} />)
+      : (
+        <SectionTitle baseComponent={"h4"} description={"No data table available for this step."} />
+      )}
     </StyledTableContainer>
   );
 


### PR DESCRIPTION
Things that will be fixed:

- some dataframe types were ignored when searching for dfs of a step.
- jumping to steps causes the start step output to be overwritten (like a yaml, thus the df value is sometimes a string and not a dataframe)
- frontend datatable component is only updating the column headers, not the cells with the values. 
