### PR TITLE
Bugfix: Run not deleted properly

### DIFF
--- a/backend/main/views_with_api.py
+++ b/backend/main/views_with_api.py
@@ -117,7 +117,11 @@ def delete_run(request):
         run_name = data.get("run_name")
 
         try:
-            delete_run_folder(run_name)
+            if run_name not in Run._instances:
+                delete_run_folder(run_name)
+            else:
+                run = Run(run_name)
+                run.delete_run()
 
             return JsonResponse({"success": True, "message": "Deleted run"})
         except Exception as e:

--- a/backend/protzilla/run.py
+++ b/backend/protzilla/run.py
@@ -200,6 +200,10 @@ class Run:
     def _run_write(self) -> None:
         self.disk_operator.write_run(self.steps)
 
+    def delete_run(self) -> None:
+        delete_run_folder(self.run_name)
+        self._instances.pop(self.run_name, None)  # remove instance from the class dictionary
+
     @property
     def run_path(self) -> str:
         return self.disk_operator.run_dir


### PR DESCRIPTION
## Description
fixes run returning when you create a new run with the same name
very small PR, one review should be enough

## Changes
in run.py the run is now removed from instances and therefore will not be reused


## Testing
- create new run, open it, make some changes
- delete that run
- create a new run with the same name
- check if its empty 
( this should cover the bug )

## PR checklist
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
