### PR TITLE
Multiple data tables

### DIFF
--- a/backend/main/views_with_api.py
+++ b/backend/main/views_with_api.py
@@ -374,7 +374,6 @@ def get_step_table(request):
                     data = run.current_outputs[dataframe]
                     data["id"] = data.index
                     cleaned_data = data.replace(np.nan, None)
-                    json_data.append({"table": cleaned_data.to_dict(orient="records"), "name": get_display_name(dataframe)}) # TODO this line should be removed when its on dev, it exists only for test purposes.
                     json_data.append({"table": cleaned_data.to_dict(orient="records"), "name": get_display_name(dataframe)}) # TODO #49 this should be refactored to be stored somewhere and not be calculated on every get_step_table (can take a few seconds)
 
         return JsonResponse({"success": True, "message": "Got the table for the step", "data": json_data}, safe=False)

--- a/backend/main/views_with_api.py
+++ b/backend/main/views_with_api.py
@@ -374,8 +374,8 @@ def get_step_table(request):
                     data = run.current_outputs[dataframe]
                     data["id"] = data.index
                     cleaned_data = data.replace(np.nan, None)
-                    json_data = cleaned_data.to_dict(orient="records") # TODO #49 this should be refactored to be stored somewhere and not be calculated on every get_step_table (can take a few seconds)
-                    break
+                    json_data.append(cleaned_data.to_dict(orient="records")) # TODO this line should be removed when its on dev, it exists only for test purposes.
+                    json_data.append(cleaned_data.to_dict(orient="records")) # TODO #49 this should be refactored to be stored somewhere and not be calculated on every get_step_table (can take a few seconds)
 
         return JsonResponse({"success": True, "message": "Got the table for the step", "data": json_data}, safe=False)
     else:

--- a/backend/main/views_with_api.py
+++ b/backend/main/views_with_api.py
@@ -19,7 +19,7 @@ from backend.protzilla.constants.paths import EXTERNAL_DATA_PATH, WORKFLOWS_PATH
 from backend.protzilla.utilities import format_trace, get_memory_usage
 from backend.protzilla.stepfactory import StepFactory
 from backend.protzilla.steps import Step
-from backend.main.views_with_api_helper import get_step, get_displayed_steps, parameters_from_post, get_all_possible_steps
+from backend.main.views_with_api_helper import get_display_name, get_step, get_displayed_steps, parameters_from_post, get_all_possible_steps
 
 database_metadata_path = EXTERNAL_DATA_PATH / "internal" / "metadata" / "uniprot.json"
 
@@ -374,8 +374,8 @@ def get_step_table(request):
                     data = run.current_outputs[dataframe]
                     data["id"] = data.index
                     cleaned_data = data.replace(np.nan, None)
-                    json_data.append(cleaned_data.to_dict(orient="records")) # TODO this line should be removed when its on dev, it exists only for test purposes.
-                    json_data.append(cleaned_data.to_dict(orient="records")) # TODO #49 this should be refactored to be stored somewhere and not be calculated on every get_step_table (can take a few seconds)
+                    json_data.append({"table": cleaned_data.to_dict(orient="records"), "name": get_display_name(dataframe)}) # TODO this line should be removed when its on dev, it exists only for test purposes.
+                    json_data.append({"table": cleaned_data.to_dict(orient="records"), "name": get_display_name(dataframe)}) # TODO #49 this should be refactored to be stored somewhere and not be calculated on every get_step_table (can take a few seconds)
 
         return JsonResponse({"success": True, "message": "Got the table for the step", "data": json_data}, safe=False)
     else:

--- a/backend/main/views_with_api_helper.py
+++ b/backend/main/views_with_api_helper.py
@@ -146,8 +146,3 @@ def set_filtered_data(run, index, key, filtered_data):
 
 def get_display_name(dataframe):
     name = dataframe.replace("_df", "")
-    name = name.capitalize()
-    if "data" in name:
-        return name
-    else:
-        return name + "-Data"

--- a/backend/main/views_with_api_helper.py
+++ b/backend/main/views_with_api_helper.py
@@ -143,3 +143,11 @@ def set_filtered_data(run, index, key, filtered_data):
         run.steps.previous_steps[index].datatable_filtered_output[key] = filtered_data
     else:
         run.current_filtered_data[key] = filtered_data
+
+def get_display_name(dataframe):
+    name = dataframe.replace("_df", "")
+    name = name.capitalize()
+    if "data" in name:
+        return name
+    else:
+        return name + "-Data"

--- a/frontend/src/components/app/index-screen/index-screen.tsx
+++ b/frontend/src/components/app/index-screen/index-screen.tsx
@@ -261,7 +261,7 @@ export const IndexScreen: React.FC = () => {
     });
     if (response.success) {
       notify({
-        title: "Imported successfull",
+        title: "Imported successfully",
         message: `Workflow ${String(workflow)} has been imported as ${newName == "" ? String(workflow).replace(".yaml", "") : String(newName)}`,
         type: "success",
       });

--- a/frontend/src/components/app/run-screen/run-screen.tsx
+++ b/frontend/src/components/app/run-screen/run-screen.tsx
@@ -1,4 +1,3 @@
-import { GridValidRowModel } from "@mui/x-data-grid";
 import { ListEditor, Navbar, PlotDownloadSettings } from "@protzilla/app";
 import {
   CSVButton,
@@ -15,6 +14,7 @@ import { useToggleableState } from "@protzilla/hooks";
 import { spacing, useTheme } from "@protzilla/theme";
 import {
   callApiWithParameters,
+  ProtzillaTable,
   dummyTextComponent1,
   emptyRunData,
   footerMessages,
@@ -83,7 +83,7 @@ export const RunScreen: React.FC = () => {
   const [runData, setRunData] = useState(emptyRunData);
   const [plots, setPlots] = useState<Figure[]>();
   const [selectedPlot, setSelectedPlot] = useState<Figure>({ data: [], layout: {} });
-  const [tableData, setTableData] = useState<(readonly GridValidRowModel[])[]>();
+  const [tableData, setTableData] = useState<ProtzillaTable[]>();
 
   const [isDownloadModalOpen, openDownloadModal, closeDownloadModal] = useToggleableState(false);
 
@@ -192,9 +192,9 @@ export const RunScreen: React.FC = () => {
         <>
           {tableData.map((table, index) => (
             <StyledContentDiv key={index}>
-              <H5>Tabelle mit Nummer</H5>
-              <DataTable data={table} />
-              <CSVButton data={table} style={{ width: "auto", alignSelf: "flex-end", marginTop: theme.spacing.buttonGap }} />
+              <H5>{table.name}</H5>
+              <DataTable data={table.table} />
+              <CSVButton data={table.table} style={{ width: "auto", alignSelf: "flex-end", marginTop: theme.spacing.buttonGap }} />
             </StyledContentDiv>
           ))}
         </>

--- a/frontend/src/components/app/run-screen/run-screen.tsx
+++ b/frontend/src/components/app/run-screen/run-screen.tsx
@@ -1,3 +1,4 @@
+import { GridValidRowModel } from "@mui/x-data-grid";
 import { ListEditor, Navbar, PlotDownloadSettings } from "@protzilla/app";
 import {
   CSVButton,
@@ -16,7 +17,6 @@ import {
   dummyTextComponent1,
   emptyRunData,
   footerMessages,
-  mockTableData,
   SelectedStep,
 } from "@protzilla/utils";
 import { Figure } from "plotly.js";
@@ -81,7 +81,7 @@ export const RunScreen: React.FC = () => {
   const [runData, setRunData] = useState(emptyRunData);
   const [plots, setPlots] = useState<Figure[]>();
   const [selectedPlot, setSelectedPlot] = useState<Figure>({ data: [], layout: {} });
-  const [tableData, setTableData] = useState([mockTableData]);
+  const [tableData, setTableData] = useState<(readonly GridValidRowModel[])[]>();
 
   const [isDownloadModalOpen, openDownloadModal, closeDownloadModal] = useToggleableState(false);
 

--- a/frontend/src/components/app/run-screen/run-screen.tsx
+++ b/frontend/src/components/app/run-screen/run-screen.tsx
@@ -14,10 +14,10 @@ import { useToggleableState } from "@protzilla/hooks";
 import { spacing, useTheme } from "@protzilla/theme";
 import {
   callApiWithParameters,
-  ProtzillaTable,
   dummyTextComponent1,
   emptyRunData,
   footerMessages,
+  ProtzillaTable,
   SelectedStep,
 } from "@protzilla/utils";
 import { Figure } from "plotly.js";

--- a/frontend/src/components/app/run-screen/run-screen.tsx
+++ b/frontend/src/components/app/run-screen/run-screen.tsx
@@ -17,8 +17,8 @@ import {
   dummyTextComponent1,
   emptyRunData,
   footerMessages,
-  Table,
   SelectedStep,
+  Table,
 } from "@protzilla/utils";
 import { Figure } from "plotly.js";
 import React, { useCallback, useEffect, useState } from "react";

--- a/frontend/src/components/app/run-screen/run-screen.tsx
+++ b/frontend/src/components/app/run-screen/run-screen.tsx
@@ -17,7 +17,7 @@ import {
   dummyTextComponent1,
   emptyRunData,
   footerMessages,
-  ProtzillaTable,
+  Table,
   SelectedStep,
 } from "@protzilla/utils";
 import { Figure } from "plotly.js";
@@ -87,7 +87,7 @@ export const RunScreen: React.FC = () => {
   const [runData, setRunData] = useState(emptyRunData);
   const [plots, setPlots] = useState<Figure[]>();
   const [selectedPlot, setSelectedPlot] = useState<Figure>({ data: [], layout: {} });
-  const [tableData, setTableData] = useState<ProtzillaTable[]>();
+  const [tableData, setTableData] = useState<Table[]>();
 
   const [isDownloadModalOpen, openDownloadModal, closeDownloadModal] = useToggleableState(false);
 

--- a/frontend/src/components/app/run-screen/run-screen.tsx
+++ b/frontend/src/components/app/run-screen/run-screen.tsx
@@ -5,6 +5,7 @@ import {
   DataTable,
   FlexColumn,
   FlexRow,
+  H5,
   PlotComponent,
   SecondaryButton,
   SectionTitle,
@@ -55,12 +56,13 @@ const StyledContentContainer = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
+  gap: ${spacing("small")};
 `;
 
 const StyledContentDiv = styled.div`
   display: flex;
   flex-direction: column;
-`
+`;
 
 const FooterText = styled.div`
   text-align: center;
@@ -190,8 +192,9 @@ export const RunScreen: React.FC = () => {
         <>
           {tableData.map((table, index) => (
             <StyledContentDiv key={index}>
+              <H5>Tabelle mit Nummer</H5>
               <DataTable data={table} />
-              <CSVButton data={table} style={{ marginTop: theme.spacing.buttonGap }} />
+              <CSVButton data={table} style={{ width: "auto", alignSelf: "flex-end", marginTop: theme.spacing.buttonGap }} />
             </StyledContentDiv>
           ))}
         </>
@@ -239,9 +242,9 @@ export const RunScreen: React.FC = () => {
         <StyledFlexColumn style={{ flex: 1 }}>
           <StyledCol>
             <SwitchCard
-              nameComponent1="Plot"
+              nameComponent1="Plots"
               component1={plotComponent}
-              nameComponent2="Table"
+              nameComponent2="Tables"
               component2={tableComponent}
             />
           </StyledCol>

--- a/frontend/src/components/app/run-screen/run-screen.tsx
+++ b/frontend/src/components/app/run-screen/run-screen.tsx
@@ -82,7 +82,7 @@ export const RunScreen: React.FC = () => {
   const [runData, setRunData] = useState(emptyRunData);
   const [plots, setPlots] = useState<Figure[]>();
   const [selectedPlot, setSelectedPlot] = useState<Figure>({ data: [], layout: {} });
-  const [tableData, setTableData] = useState(mockTableData);
+  const [tableData, setTableData] = useState([mockTableData]);
 
   const [isDownloadModalOpen, openDownloadModal, closeDownloadModal] = useToggleableState(false);
 
@@ -187,11 +187,15 @@ export const RunScreen: React.FC = () => {
 
   const tableComponent = (
     <StyledTableContainer>
-      {tableData.length > 0 ? (
-        <div>
-          <DataTable data={tableData} />
-          <CSVButton data={tableData} style={{ marginTop: theme.spacing.buttonGap }} />
-        </div>
+      {tableData && tableData.length > 0 ? (
+        <>
+          {tableData.map((table, index) => (
+            <div key={index} style={{ display: "flex", flexDirection: "column" }}>
+              <DataTable data={table} />
+              <CSVButton data={table} style={{ marginTop: theme.spacing.buttonGap }} />
+            </div>
+          ))}
+        </>
       ) : (
         <SectionTitle baseComponent={"h4"} description={"No data table available for this step."} />
       )}

--- a/frontend/src/components/app/run-screen/run-screen.tsx
+++ b/frontend/src/components/app/run-screen/run-screen.tsx
@@ -51,17 +51,16 @@ const StyledListSwitchCard = styled(SwitchCard)`
   height: 100%;
 `;
 
-const StyledPlotContainer = styled.div`
+const StyledContentContainer = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
 `;
 
-const StyledTableContainer = styled.div`
-  width: 100%;
+const StyledContentDiv = styled.div`
   display: flex;
   flex-direction: column;
-`;
+`
 
 const FooterText = styled.div`
   text-align: center;
@@ -157,11 +156,11 @@ export const RunScreen: React.FC = () => {
   };
 
   const plotComponent = (
-    <StyledPlotContainer>
+    <StyledContentContainer>
       {plots && plots.length > 0 ? (
         <>
           {plots.map((plot, index) => (
-            <div key={index} style={{ display: "flex", flexDirection: "column" }}>
+            <StyledContentDiv key={index}>
               <PlotComponent data={plot.data} layout={plot.layout} hasResizing={true} />
               <SecondaryButton
                 text="Download plot"
@@ -170,7 +169,7 @@ export const RunScreen: React.FC = () => {
                   handleDownloadPlot(plot);
                 }}
               />
-            </div>
+            </StyledContentDiv>
           ))}
           <PlotDownloadSettings
             isOpen={isDownloadModalOpen}
@@ -182,24 +181,24 @@ export const RunScreen: React.FC = () => {
       ) : (
         <SectionTitle baseComponent={"h4"} description={"No plot available for this step."} />
       )}
-    </StyledPlotContainer>
+    </StyledContentContainer>
   );
 
   const tableComponent = (
-    <StyledTableContainer>
+    <StyledContentContainer>
       {tableData && tableData.length > 0 ? (
         <>
           {tableData.map((table, index) => (
-            <div key={index} style={{ display: "flex", flexDirection: "column" }}>
+            <StyledContentDiv key={index}>
               <DataTable data={table} />
               <CSVButton data={table} style={{ marginTop: theme.spacing.buttonGap }} />
-            </div>
+            </StyledContentDiv>
           ))}
         </>
       ) : (
         <SectionTitle baseComponent={"h4"} description={"No data table available for this step."} />
       )}
-    </StyledTableContainer>
+    </StyledContentContainer>
   );
 
   const listEditorComponent = (

--- a/frontend/src/components/app/run-screen/run-screen.tsx
+++ b/frontend/src/components/app/run-screen/run-screen.tsx
@@ -72,6 +72,10 @@ const FooterText = styled.div`
   width: 100%;
 `;
 
+const  TableHeader = styled(H5)`
+  margin-bottom: ${spacing("small")};
+`
+
 export const RunScreen: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -192,7 +196,7 @@ export const RunScreen: React.FC = () => {
         <>
           {tableData.map((table, index) => (
             <StyledContentDiv key={index}>
-              <H5>{table.name}</H5>
+              <TableHeader>{table.name}</TableHeader>
               <DataTable data={table.table} />
               <CSVButton data={table.table} style={{ width: "auto", alignSelf: "flex-end", marginTop: theme.spacing.buttonGap }} />
             </StyledContentDiv>

--- a/frontend/src/utils/mockUpData.ts
+++ b/frontend/src/utils/mockUpData.ts
@@ -28,6 +28,7 @@ export const mockPlots: Figure[] = [
   },
 ];
 
+//for testing purposes
 export const mockTableData: GridRowsProp = [
   {
     Sample: "AD01_C1_INSOLUBLE_01",

--- a/frontend/src/utils/protzilla-types.ts
+++ b/frontend/src/utils/protzilla-types.ts
@@ -78,7 +78,7 @@ export const emptyRunData: RunData = {
   memory_usage: "",
 };
 
-export interface ProtzillaTable {
+export interface Table {
   table: (readonly GridValidRowModel[]);
   name: string;
 }

--- a/frontend/src/utils/protzilla-types.ts
+++ b/frontend/src/utils/protzilla-types.ts
@@ -1,3 +1,5 @@
+import { GridValidRowModel } from "@mui/x-data-grid";
+
 export interface UIStateProps {
   isDisabled?: boolean;
 }
@@ -75,6 +77,11 @@ export const emptyRunData: RunData = {
   displayed_steps: emptySections,
   memory_usage: "",
 };
+
+export interface ProtzillaTable {
+  table: (readonly GridValidRowModel[]);
+  name: string;
+}
 
 export interface RequestData {
   index: number;


### PR DESCRIPTION
## Description
Multiple data tables can now be displayed. 
Only when PR#43 is on dev do some steps have multiple dataframes -> currently the singular df that a step has is being duplicated in the backend, that line will be remove before merge.

## Changes
Changed the data table component to create as many datatables as needed.
Backend now provides all approved dataframes that a step has.
Extracted style from plot and datatable component to combat code duplication.

## Testing
<!-- How to test the changes made in the pull-request, e.g. a walkthrough with steps of a sample workflow. -->

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
