### PR TITLE
single-checkbox bug (only in database settings)

### DIFF
--- a/frontend/src/components/app/settings/other-settings/database-settings.tsx
+++ b/frontend/src/components/app/settings/other-settings/database-settings.tsx
@@ -204,7 +204,7 @@ export const DatabaseSettings = () => {
           void handleAddDatabase(
             data.database_name as string,
             data.database_file as string,
-            data.verification_checkbox === "true",
+            data.verification_checkbox as boolean,
           );
         }}
       />


### PR DESCRIPTION
Die checkbox funktioniert doch, war nur von mir in den database settings nicht richtig implementiert und hat daher genau dort nicht funktioniert. Ist mit einer Zeile gefixt