### PR TITLE
fixed husky

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,1 +1,2 @@
+cd frontend
 pnpx lint-staged

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit --pretty -p ./tsconfig.app.json",
     "test": "vitest run --passWithNoTests",
     "preview": "vite preview",
-    "prepare": "husky",
+    "prepare": "cd .. && husky frontend/.husky",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
@@ -86,6 +86,12 @@
   "eslintConfig": {
     "extends": [
       "plugin:storybook/recommended"
+    ]
+  },
+  "lint-staged": {
+    "**/*.{js,ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
     ]
   }
 }


### PR DESCRIPTION
Husky now runs with our .git in the main folder. It will lint and format staged files before each commit.

To use it, you need to run pnpm prepare once. If you run pnpm install, this is done automatically, so it is included in our run-protzilla scripts.

To test whether the commit hooks are being executed, add 'exit 1' to the /frontend/.husky/pre-commit file and then try committing your changes. Your commit should then fail.
To test whether the linter runs, add an unused variable to an .ts file. The commit should then fail too. 