### PR TITLE
fix: Modal stays open after clicking icon plus button

### DIFF
--- a/frontend/src/components/app/run-screen/step-selection/step-selection.tsx
+++ b/frontend/src/components/app/run-screen/step-selection/step-selection.tsx
@@ -222,9 +222,6 @@ export const StepSelection: React.FC<StepSelectionProps> = ({
           onMouseEnter={() => {
             setShowHandle(true);
           }}
-          onMouseLeave={() => {
-            setShowHandle(false);
-          }}
         />
       ) : (
         <GrayButton


### PR DESCRIPTION
## Description
fixes #95 
When clicking the icon plus button (appears when hovering between steps), the pop-up actually stays open. 

## Changes
In the file step-selection.tsx, we removed the onMouseLeave function of the iconButton. 


## Testing
If the hovering of the iconButton works and wether the pop-up stays open. 

## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
