### PR TITLE
Add Form definition to classes without form

### DIFF
--- a/backend/protzilla/form_helper.py
+++ b/backend/protzilla/form_helper.py
@@ -5,9 +5,9 @@ from backend.protzilla.steps import Step
 
 def to_choices(choices: list[str], required: bool = True) -> list[Option]:
     return (
-        [Option(el, el) for el in choices] + [Option(None, "---------")]
+        [Option(str(el), str(el)) for el in choices] + [Option(None, "---------")]
         if not required
-        else [Option(el, el) for el in choices]
+        else [Option(str(el), str(el)) for el in choices]
     )
 
 

--- a/backend/protzilla/methods/data_analysis.py
+++ b/backend/protzilla/methods/data_analysis.py
@@ -225,7 +225,7 @@ class DifferentialExpressionANOVA(DataAnalysisStep):
                     separatePrefix="\u03B1",
                 ),
                 DropdownField(name="grouping", label="Grouping from metadata"),
-                DropdownField(
+                MultiSelectField(
                     name="selected_groups", label="Select groups to perform ANOVA on"
                 ),
             ],
@@ -249,7 +249,9 @@ class DifferentialExpressionANOVA(DataAnalysisStep):
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
         inputs["log_base"] = steps.get_step_input(TransformationLog, "log_base")
-        inputs["intensity_df"] = steps.protein_df
+        inputs["intensity_df"] = steps.get_step_input(
+            Step, "protein_df", inputs["protein_df"]
+        )
         inputs["metadata_df"] = steps.metadata_df
         return inputs
 
@@ -355,7 +357,9 @@ class DifferentialExpressionTTest(DataAnalysisStep):
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
         inputs["log_base"] = steps.get_step_input(TransformationLog, "log_base")
-        inputs["intensity_df"] = steps.protein_df
+        inputs["intensity_df"] = steps.get_step_input(
+            Step, "protein_df", inputs["protein_df"]
+        )
         inputs["metadata_df"] = steps.metadata_df
         return inputs
 
@@ -714,7 +718,7 @@ class DifferentialExpressionKruskalWallisOnIntensity(DataAnalysisStep):
                     separatePrefix="\u03B1",
                 ),
                 DropdownField(name="grouping", label="Grouping from metadata"),
-                DropdownField(
+                MultiSelectField(
                     name="selected_groups",
                     label="Select groups to perform Kruskal-Wallis Test on",
                 ),
@@ -738,8 +742,11 @@ class DifferentialExpressionKruskalWallisOnIntensity(DataAnalysisStep):
     calc_method = staticmethod(kruskal_wallis_test_on_intensity_data)
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
-        inputs["ptm_df"] = steps.get_step_output(Step, "ptm_df", inputs["ptm_df"])
+        inputs["protein_df"] = steps.get_step_output(
+            Step, "protein_df", inputs["protein_df"]
+        )
         inputs["metadata_df"] = steps.metadata_df
+        inputs["log_base"] = steps.get_step_input(TransformationLog, "log_base")
         return inputs
 
 
@@ -779,7 +786,7 @@ class DifferentialExpressionKruskalWallisOnPTM(DataAnalysisStep):
                     separatePrefix="\u03B1",
                 ),
                 DropdownField(name="grouping", label="Grouping from metadata"),
-                DropdownField(
+                MultiSelectField(
                     name="selected_groups",
                     label="Select groups to perform Kruskal-Wallis Test on",
                 ),
@@ -1996,6 +2003,7 @@ class FLEXIQuantLF(DataAnalysisStep):
         )
 
         inputs["metadata_df"] = steps.metadata_df
+        return inputs
 
 
 class SelectPeptidesForProtein(DataAnalysisStep):

--- a/backend/protzilla/methods/data_analysis.py
+++ b/backend/protzilla/methods/data_analysis.py
@@ -32,7 +32,7 @@ from backend.protzilla.data_analysis.ptm_analysis import (
 )
 from backend.protzilla.data_analysis.ptm_quantification import flexiquant_lf
 from backend.protzilla.form import *
-from backend.protzilla.methods.data_preprocessing import TransformationLog
+from backend.protzilla.methods.data_preprocessing import TransformationLog, DataPreprocessingStep
 from backend.protzilla.steps import Plots, Step, StepManager
 
 
@@ -185,6 +185,53 @@ class DifferentialExpressionANOVA(DataAnalysisStep):
         "filtered_proteins",
     ]
 
+    def create_form(self):
+        return Form(
+            label="ANOVA",
+            input_fields=[
+                DropdownField(
+                    name="protein_df",
+                    label="Step to use protein intensities from"
+                ),
+                DropdownField(
+                    name="multiple_testing_correction_method",
+                    label="Multiple testing correction",
+                    options=MultipleTestingCorrectionMethod,
+                    value=MultipleTestingCorrectionMethod.benjamini_hochberg,
+                ),
+                FloatField(
+                    name="alpha",
+                    label="Error rate (alpha)",
+                    value=0.05,
+                    min=0,
+                    max=1,
+                    step=0.01,
+                    separatePrefix="\u03B1",
+                ),
+                DropdownField(
+                    name="grouping",
+                    label="Grouping from metadata"
+                ),
+                DropdownField(
+                    name="selected_groups",
+                    label="Select groups to perform ANOVA on"
+                ),
+            ]
+        )
+    
+    def modify_form(self, form, run):
+        protein_df_field = form["protein_df"]
+        grouping_field = form["grouping"]
+        selected_groups_field = form["selected_groups"]
+
+        protein_df_field.set_options(form_helper.get_choices_for_protein_df_steps(run))
+        grouping_field.set_options(form_helper.get_choices_for_metadata_non_sample_columns(run))
+        grouping = grouping_field.value
+        selected_groups_field.set_options(form_helper.to_choices(
+            run.steps.metadata_df[grouping].unique()
+        ))
+
+
     calc_method = staticmethod(anova)
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
@@ -304,6 +351,67 @@ class DifferentialExpressionLinearModel(DataAnalysisStep):
         "filtered_proteins",
     ]
 
+    def create_form(self):
+        return Form(
+            label="Linear Model",
+            input_fields=[
+                DropdownField(
+                    name="multiple_testing_correction_method",
+                    label="Multiple testing correction",
+                    options=MultipleTestingCorrectionMethod,
+                    value=MultipleTestingCorrectionMethod.benjamini_hochberg,
+                ),
+                FloatField(
+                    name="alpha",
+                    label="Error rate (alpha)",
+                    value=0.05,
+                    min=0,
+                    max=1,
+                    step=0.01,
+                    separatePrefix="\u03B1",
+                ),
+                DropdownField(
+                    name="grouping",
+                    label="Grouping from metadata",
+                ),
+                DropdownField(
+                    name="group1",
+                    label="Group 1",
+                ),
+                DropdownField(
+                    name="group2",
+                    label="Group 2",
+                ),
+            ]
+        )
+
+    def modify_form(self, form, run):
+        grouping_field = form["grouping"]
+        group1_field = form["group1"]
+        group2_field = form["group2"]
+
+        grouping_field.set_options(form_helper.get_choices_for_metadata_non_sample_columns(run))
+
+        if (grouping_field.options == []):
+            return
+        
+        grouping = grouping_field.value
+
+        # Set choices for group1 field based on selected grouping
+        group1_field.set_options(form_helper.to_choices(run.steps.metadata_df[grouping].unique()))
+
+        #set choices for group2 field based on selected grouping and group1
+        if (group1_field.value in run.steps.metadata_df[grouping].unique()):
+            group2_field.set_options([
+                Option(el, el)
+                for el in run.steps.metadata_df[grouping].unique()
+                if el != group1_field.value
+            ])
+        else:
+            group2_field.set_options(list(reversed(
+                form_helper.to_choices(run.steps.metadata_df[grouping].unique()))
+            ))
+
     calc_method = staticmethod(linear_model)
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
@@ -327,6 +435,79 @@ class DifferentialExpressionMannWhitneyOnIntensity(DataAnalysisStep):
         "log2_fold_change_df",
         "corrected_alpha",
     ]
+
+    def create_form(self):
+        return Form(
+            label="Mann-Whitney Test",
+            input_fields=[
+                DropdownField(
+                    name="protein_df",
+                    label="Step to use protein intensities from",
+                ),
+                DropdownField(
+                    name="multiple_testing_correction_method",
+                    label="Multiple testing correction",
+                    value=MultipleTestingCorrectionMethod.benjamini_hochberg,
+                    options=MultipleTestingCorrectionMethod,
+                ),
+                FloatField(
+                    name="alpha",
+                    label="Error rate (alpha)",
+                    value=0.05,
+                    min=0,
+                    max=1,
+                    step=0.01,
+                    separatePrefix="\u03B1",
+                ),
+                DropdownField(
+                    name="p_value_calculation_method",
+                    label="P-value calculation method",
+                    options=PValueCalculationMethod,
+                    value=PValueCalculationMethod.auto,
+                ),
+                DropdownField(
+                    name="grouping",
+                    label="Grouping from metadata",
+                ),
+                DropdownField(
+                    name="group1",
+                    label="Group 1",
+                ),
+                DropdownField(
+                    name="group2",
+                    label="Group 2",
+                ),
+            ]
+        )
+
+    def modify_form(self, form, run):
+        protein_field = form["protein_df"]
+        grouping_field = form["grouping"]
+        group1_field = form["group1"]
+        group2_field = form["group2"]
+
+        protein_field.set_options(form_helper.get_choices_for_protein_df_steps(run))
+        grouping_field.set_options(form_helper.get_choices_for_metadata_non_sample_columns(run))
+
+        if (grouping_field.options == []):
+            return
+        
+        grouping = grouping_field.value
+
+        # Set choices for group1 field based on selected grouping
+        group1_field.set_options(form_helper.to_choices(run.steps.metadata_df[grouping].unique()))
+
+        #set choices for group2 field based on selected grouping and group1
+        if (group1_field.value in run.steps.metadata_df[grouping].unique()):
+            group2_field.set_options([
+                Option(el, el)
+                for el in run.steps.metadata_df[grouping].unique()
+                if el != group1_field.value
+            ])
+        else:
+            group2_field.set_options(list(reversed(
+                form_helper.to_choices(run.steps.metadata_df[grouping].unique()))
+            ))
 
     calc_method = staticmethod(mann_whitney_test_on_intensity_data)
 
@@ -353,6 +534,79 @@ class DifferentialExpressionMannWhitneyOnPTM(DataAnalysisStep):
         "corrected_alpha",
     ]
 
+    def create_form(self):
+        return Form(
+            label="Mann-Whitney Test",
+            input_fields=[
+                DropdownField(
+                    name="ptm_df",
+                    label="Step to use ptm data from",
+                ),
+                DropdownField(
+                    name="multiple_testing_correction_method",
+                    label="Multiple testing correction",
+                    value=MultipleTestingCorrectionMethod.benjamini_hochberg,
+                    options=MultipleTestingCorrectionMethod,
+                ),
+                FloatField(
+                    name="alpha",
+                    label="Error rate (alpha)",
+                    value=0.05,
+                    min=0,
+                    max=1,
+                    step=0.01,
+                    separatePrefix="\u03B1",
+                ),
+                DropdownField(
+                    name="p_value_calculation_method",
+                    label="P-value calculation method",
+                    options=PValueCalculationMethod,
+                    value=PValueCalculationMethod.auto,
+                ),
+                DropdownField(
+                    name="grouping",
+                    label="Grouping from metadata",
+                ),
+                DropdownField(
+                    name="group1",
+                    label="Group 1",
+                ),
+                DropdownField(
+                    name="group2",
+                    label="Group 2",
+                ),
+            ]
+        )
+
+    def modify_form(self, form, run):
+        ptm_df_field = form["ptm_df"]
+        grouping_field = form["grouping"]
+        group1_field = form["group1"]
+        group2_field = form["group2"]
+
+        ptm_df_field.set_options(form_helper.to_choices(run.steps.get_instance_identifiers(PTMsPerSample, "ptm_df")))
+        grouping_field.set_options(form_helper.get_choices_for_metadata_non_sample_columns(run))
+
+        if (grouping_field.options == []):
+            return
+        
+        grouping = grouping_field.value
+
+        # Set choices for group1 field based on selected grouping
+        group1_field.set_options(form_helper.to_choices(run.steps.metadata_df[grouping].unique()))
+
+        #set choices for group2 field based on selected grouping and group1
+        if (group1_field.value in run.steps.metadata_df[grouping].unique()):
+            group2_field.set_options([
+                Option(el, el)
+                for el in run.steps.metadata_df[grouping].unique()
+                if el != group1_field.value
+            ])
+        else:
+            group2_field.set_options(list(reversed(
+                form_helper.to_choices(run.steps.metadata_df[grouping].unique()))
+            ))
+
     calc_method = staticmethod(mann_whitney_test_on_ptm_data)
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
@@ -374,33 +628,57 @@ class DifferentialExpressionKruskalWallisOnIntensity(DataAnalysisStep):
         "corrected_alpha",
     ]
 
+    def create_form(self):
+        return Form(
+            label="Kruskal-Wallis Test",
+            input_fields=[
+                DropdownField(
+                    name="protein_df",
+                    label="Step to use protein data from"
+                ),
+                DropdownField(
+                    name="multiple_testing_correction_method",
+                    label="Multiple testing correction",
+                    options=MultipleTestingCorrectionMethod,
+                    value=MultipleTestingCorrectionMethod.benjamini_hochberg,
+                ),
+                FloatField(
+                    name="alpha",
+                    label="Error rate (alpha)",
+                    value=0.05,
+                    min=0,
+                    max=1,
+                    step=0.01,
+                    separatePrefix="\u03B1",
+                ),
+                DropdownField(
+                    name="grouping",
+                    label="Grouping from metadata"
+                ),
+                DropdownField(
+                    name="selected_groups",
+                    label="Select groups to perform Kruskal-Wallis Test on"
+                ),
+            ]
+        )
+    
+    def modify_form(self, form, run):
+        protein_df_field = form["protein_df"]
+        grouping_field = form["grouping"]
+        selected_groups_field = form["selected_groups"]
+
+        protein_df_field.set_options(form_helper.get_choices_for_protein_df_steps(run))
+        grouping_field.set_options(form_helper.get_choices_for_metadata_non_sample_columns(run))
+        grouping = grouping_field.value
+        selected_groups_field.set_options(form_helper.to_choices(
+            run.steps.metadata_df[grouping].unique()
+        ))
+
     calc_method = staticmethod(kruskal_wallis_test_on_intensity_data)
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
         inputs["ptm_df"] = steps.get_step_output(Step, "ptm_df", inputs["ptm_df"])
         inputs["metadata_df"] = steps.metadata_df
-        return inputs
-
-
-class DifferentialExpressionKruskalWallisOnIntensity(DataAnalysisStep):
-    display_name = "Kruskal-Wallis Test"
-    operation = "differential_expression"
-    method_description = ("A function to conduct a Kruskal-Wallis test between groups defined in the clinical data."
-                          "The p-values are corrected for multiple testing.")
-
-    output_keys = [
-        "differentially_expressed_proteins_df",
-        "significant_proteins_df",
-        "corrected_p_values_df",
-        "corrected_alpha",
-    ]
-
-    calc_method = staticmethod(kruskal_wallis_test_on_intensity_data)
-
-    def insert_dataframes(self, steps: StepManager, inputs) -> dict:
-        inputs["protein_df"] = steps.get_step_output(Step, "protein_df", inputs["protein_df"])
-        inputs["metadata_df"] = steps.metadata_df
-        inputs["log_base"] = steps.get_step_input(TransformationLog, "log_base")
         return inputs
 
 
@@ -416,6 +694,54 @@ class DifferentialExpressionKruskalWallisOnPTM(DataAnalysisStep):
         "corrected_p_values_df",
         "corrected_alpha",
     ]
+
+    def create_form(self):
+        return Form(
+            label="Kruskal-Wallis Test",
+            input_fields=[
+                DropdownField(
+                    name="ptm_df",
+                    label="Step to use ptm data from"
+                ),
+                DropdownField(
+                    name="multiple_testing_correction_method",
+                    label="Multiple testing correction",
+                    options=MultipleTestingCorrectionMethod,
+                    value=MultipleTestingCorrectionMethod.benjamini_hochberg,
+                ),
+                FloatField(
+                    name="alpha",
+                    label="Error rate (alpha)",
+                    value=0.05,
+                    min=0,
+                    max=1,
+                    step=0.01,
+                    separatePrefix="\u03B1",
+                ),
+                DropdownField(
+                    name="grouping",
+                    label="Grouping from metadata"
+                ),
+                DropdownField(
+                    name="selected_groups",
+                    label="Select groups to perform Kruskal-Wallis Test on"
+                ),
+            ]
+        )
+    
+    def modify_form(self, form, run):
+        ptm_df_field = form["ptm_df"]
+        grouping_field = form["grouping"]
+        selected_groups_field = form["selected_groups"]
+
+        ptm_df_field.set_options(form_helper.to_choices(
+            run.steps.get_instance_identifiers(PTMsPerSample, "ptm_df")
+        ))
+        grouping_field.set_options(form_helper.get_choices_for_metadata_non_sample_columns(run))
+        grouping = grouping_field.value
+        selected_groups_field.set_options(form_helper.to_choices(
+            run.steps.metadata_df[grouping].unique()
+        ))
 
     calc_method = staticmethod(kruskal_wallis_test_on_ptm_data)
 
@@ -485,7 +811,7 @@ class PlotVolcano(DataAnalysisStep):
         if step_output is not None:
             items_of_interest = step_output["PTM"].unique()
 
-        items_of_interest_field.options = (form_helper.to_choices(items_of_interest))
+        items_of_interest_field.set_options(form_helper.to_choices(items_of_interest))
 
     plot_method = staticmethod(create_volcano_plot)
 
@@ -519,6 +845,38 @@ class PlotScatterPlot(DataAnalysisStep):
 
     plot_method = staticmethod(scatter_plot)
 
+    def create_form(self):
+        return Form(
+            label = "Scatter Plot",
+            input_fields=[
+                DropdownField(
+                    name = "input_df",
+                    label = "Choose dataframe to be plotted",
+                ),
+                #TODO: handle isRequired
+                DropdownField(
+                    name = "color_df",
+                    label = "Choose dataframe to be used for coloring",
+                ),
+            ],
+        )
+    
+    def modify_form(self, form, run):
+        input_df_field = form["input_df"]
+        color_field = form["color_df"]
+
+        input_df_field.set_options(
+            form_helper.to_choices(
+                run.steps.get_instance_identifiers(DimensionReductionUMAP, "embedded_data")
+            )
+        )
+
+        color_field.set_options(
+            form_helper.to_choices(
+                run.steps.get_instance_identifiers(Step, "color_df"), required=False
+            )
+        ) 
+
     # TODO: input
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
         inputs["input_df"] = steps.get_step_output(
@@ -535,6 +893,29 @@ class PlotClustergram(DataAnalysisStep):
 
     plot_method = staticmethod(clustergram_plot)
 
+    #TODO: handle isRequired with sample_group_df
+    def create_form(self):
+        return Form(
+            label="Clustergram",
+            input_fields=[
+                DropdownField(
+                    name="input_df",
+                    label="Choose dataframe to be plotted",
+                    options=AnalysisLevel,
+                ),
+                DropdownField(
+                    name="sample_group_df",
+                    label="Choose dataframe to be used for coloring",
+                ),
+                DropdownField(
+                    name="flip_axes",
+                    label="Flip axis",
+                    options=YesNo,
+                    value=YesNo.no,
+                ),
+            ]
+        )
+    
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
         inputs["input_df"] = steps.protein_df
         inputs["sample_group_df"] = steps.metadata_df
@@ -582,21 +963,21 @@ class PlotProtQuant(DataAnalysisStep):
         )
 
     def modify_form(self, form, run):
-        form["input_df"].options = form_helper.get_choices_for_protein_df_steps(
+        form["input_df"].set_options(form_helper.get_choices_for_protein_df_steps(
             run
-        )
+        ))
 
         if (form["input_df"].options):
             if (not form["input_df"].value):
                 form["input_df"].value = form["input_df"].options[0].label
 
-            form["protein_group"].options = form_helper.to_choices(
+            form["protein_group"].set_options(form_helper.to_choices(
                 run.steps.get_step_output(
                     step_type=Step,
                     output_key="protein_df",
                     instance_identifier=form["input_df"].value,
                 )["Protein ID"].unique()
-            )
+            ))
 
         if form["similarity_measure"].value == SimilarityMeasure.cosine_similarity:
             form["similarity"] = FloatField(
@@ -669,6 +1050,87 @@ class ClusteringKMeans(DataAnalysisStep):
 
     calc_method = staticmethod(k_means)
 
+    def create_form(self):
+        return Form(
+            label="kMeans",
+            input_fields=[
+                DropdownField(
+                    name="input_df",
+                    label="Choose dataframe to be plotted",
+                ),
+                # TODO: Add dynamic fill for labels_column & positive_label
+                DropdownField(
+                    name="labels_column",
+                    label="Choose labels column from metadata",
+                ),
+                DropdownField(
+                    name="positive_label",
+                    label="Choose positive class",
+                ),
+                DropdownField(
+                    name="model_selection",
+                    label="Choose strategy to perform parameter fine-tuning",
+                    options=ModelSelection,
+                    value=ModelSelection.grid_search,
+                ),
+                # TODO: Add dynamic parameters for grid search & randomized search
+                # TODO Add dynamic parameter for model selection scoring
+                DropdownField(
+                    name="model_selection_scoring",
+                    label="Select a scoring for identifying the best estimator following a grid search",
+                    options=ClusteringScoring,
+                ),
+                DropdownField(
+                    name="scoring",
+                    label="Scoring for the model",
+                    options=ClusteringScoring,
+                ),
+                NumberField(
+                    name="n_clusters",
+                    label="Number of clusters to find",
+                    min=1,
+                    step=1,
+                    value=8,
+                ),
+                NumberField(
+                    name="random_state",
+                    label="Seed for centroid initialisation",
+                    min=0,
+                    max=4294967295,
+                    step=1,
+                    value=0,
+                ),
+                DropdownField(
+                    name="init_centroid_strategy",
+                    label="Method for initialisation of centroids",
+                    options=InitCentroidStrategy,
+                    value=InitCentroidStrategy.random,
+                ),
+                NumberField(
+                    name="n_init",
+                    label="Number of times the k-means algorithm is run with different centroid seeds",
+                    min=1,
+                    step=1,
+                    value=10,
+                ),
+                NumberField(
+                    name="max_iter",
+                    label="Maximum number of iterations of the k-means algorithm for a single run",
+                    min=1,
+                    step=1,
+                    value=30,
+                ),
+                NumberField(
+                    name="tolerance",
+                    label="Relative tolerance with regards to Frobenius norm",
+                    min=0,
+                    value=1e-4,
+                ),
+
+
+            ]
+        )
+
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
         inputs["input_df"] = steps.protein_df
         inputs["sample_group_df"] = steps.metadata_df
@@ -689,6 +1151,80 @@ class ClusteringExpectationMaximisation(DataAnalysisStep):
 
     calc_method = staticmethod(expectation_maximisation)
 
+    def create_form(self):
+        return Form(
+            label="Expectation-maximization (EM)",
+            input_fields=[
+                DropdownField(
+                    name="input_df",
+                    label="Choose dataframe to be plotted",
+                    options=AnalysisLevel,
+                ),
+                # TODO: Add dynamic fill for labels_column & positive_label
+                DropdownField(
+                    name="labels_column",
+                    label="Choose labels column from metadata",
+                ),
+                DropdownField(
+                    name="positive_label",
+                    label="Choose positive class",
+                ),
+                DropdownField(
+                    name="model_selection",
+                    label="Choose strategy to perform parameter fine-tuning",
+                    options=ModelSelection,
+                    value=ModelSelection.grid_search,
+                ),
+                # TODO: Add dynamic parameters for grid search & randomized search
+                # TODO Add dynamic parameter for model selection scoring
+                DropdownField(
+                    name="model_selection_scoring",
+                    label="Select a scoring for identifying the best estimator following a grid search",
+                    options=ClusteringScoring,
+                ),
+                DropdownField(
+                    name="scoring",
+                    label="Scoring for the model",
+                    options=ClusteringScoring,
+                    value=ClusteringScoring.adjusted_rand_score,
+                ),
+                NumberField(
+                    name="n_components",
+                    label="The number of mixture components",
+                    value=1,
+                ),
+                NumberField(
+                    name="reg_covar",
+                    label="Non-negative regularization added to the diagonal of covariance",
+                    value=1e-6,
+                ),
+                MultiSelectField(
+                    name="covariance_type",
+                    label="Type of covariance",
+                    options=ClusteringCovarianceType,
+                    value=ClusteringCovarianceType.full,
+                ),
+                MultiSelectField(
+                    name="int_params",
+                    label="The method used to initialize the weights, the means and the precisions.",
+                    options=ClusteringInitParams,
+                ),
+                NumberField(
+                    name="max_iter",
+                    label="The number of EM iterations to perform",
+                    value=100,
+                ),
+                NumberField(
+                    name="random_state",
+                    label="Seed for random number generation",
+                    min=0,
+                    max=4294967295,
+                    step=1,
+                    value=0,
+                )
+            ]
+        )
+
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
         inputs["input_df"] = steps.protein_df
         inputs["sample_group_df"] = steps.metadata_df
@@ -707,6 +1243,65 @@ class ClusteringHierarchicalAgglomerative(DataAnalysisStep):
         "model_evaluation_df",
         "cluster_labels_df",
     ]
+
+    def create_form(self):
+        return Form(
+            label="Hierarchical Agglomerative Clustering",
+            input_fields=[
+                DropdownField(
+                    name="input_df",
+                    label="Choose dataframe to be plotted",
+                    options=AnalysisLevel,
+                ),
+                # TODO: Add dynamic fill for labels_column & positive_label
+                DropdownField(
+                    name="labels_column",
+                    label="Choose labels column from metadata",
+                ),
+                DropdownField(
+                    name="positive_label",
+                    label="Choose positive class",
+                ),
+                DropdownField(
+                    name="model_selection",
+                    label="Choose strategy to perform parameter fine-tuning",
+                    options=ModelSelection,
+                    value=ModelSelection.grid_search,
+                ),
+                # TODO: Add dynamic parameters for grid search & randomized search
+                # TODO Add dynamic parameter for model selection scoring
+                DropdownField(
+                    name="model_selection_scoring",
+                    label="Select a scoring for identifying the best estimator following a grid search",
+                    options=ClusteringScoring,
+                ),
+                DropdownField(
+                    name="scoring",
+                    label="Scoring for the model",
+                    options=ClusteringScoring,
+                    value=ClusteringScoring.adjusted_rand_score,
+                ),
+                NumberField(
+                    name="n_clusters",
+                    label="The number of clusters to find",
+                    min=1,
+                    step=1,
+                    value=2,
+                ),
+                MultiSelectField(
+                    name="metric",
+                    label="Distance metric",
+                    options=ClusteringMetric,
+                    value=ClusteringMetric.euclidean,
+                ),
+                MultiSelectField(
+                    name="linkage",
+                    label="The linkage criterion to use in order to to determine the distance to use between sets of observation",
+                    options=ClusteringLinkage,
+                    value=ClusteringLinkage.ward,
+                )
+            ]
+        )
 
     calc_method = staticmethod(hierarchical_agglomerative_clustering)
 
@@ -730,6 +1325,128 @@ class ClassificationRandomForest(DataAnalysisStep):
         "y_test_df",
     ]
 
+    def create_form(self):
+        return Form(
+            label="Random Forest",
+            input_fields=[
+                DropdownField(
+                    name="input_df",
+                    label="Choose dataframe to be plotted",
+                    options=AnalysisLevel,
+                ),
+                # TODO: Add dynamic fill for labels_column & positive_label
+                DropdownField(
+                    name="labels_column",
+                    label="Choose labels column from metadata",
+                ),
+                DropdownField(
+                    name="positive_label",
+                    label="Choose positive class",
+                ),
+                NumberField(
+                    name="test_size",
+                    label="Test size",
+                    min=0,
+                    value=0.20,
+                ),
+                DropdownField(
+                    name="split_stratisfy",
+                    label="Stratify the split",
+                    options=YesNo,
+                    value=YesNo.yes,
+                ),
+                # TODO: Validation strategy
+                DropdownField(
+                    name="validation_strategy",
+                    label="Validation strategy",
+                    options=ClassificationValidationStrategy,
+                    value=ClassificationValidationStrategy.k_fold,
+                ),
+                NumberField(
+                    name="train_val_split",
+                    label="Choose the size of the validation data set (you can either enter the absolute number of validation "
+                          "samples or a number between 0.0 and 1.0 to represent the percentage of validation samples)",
+                    value=0.20,
+                ),
+                NumberField(
+                    name="n_splits",
+                    label="Number of folds",
+                    min=2,
+                    value=5,
+                ),
+                DropdownField(
+                    name="shuffle",
+                    label="Whether to shuffle the data before splitting into batches",
+                    options=YesNo,
+                    value=YesNo.yes,
+                ),
+                NumberField(
+                    name="n_repeats",
+                    label="Number of times cross-validator needs to be repeated",
+                    min=1,
+                    value=10,
+                ),
+                NumberField(
+                    name="random_state_cv",
+                    label="Seed for random number generation",
+                    min=0,
+                    max=4294967295,
+                    step=1,
+                    value=42,
+                ),
+                NumberField(
+                    name="p_samples",
+                    label="Size of the test sets",
+                    value=1,
+                ),
+                MultiSelectField(
+                    name="scoring",
+                    label="Scoring for the model",
+                    options=ClassificationScoring,
+                    value=ClassificationScoring.accuracy,
+                ),
+                DropdownField(
+                    name="model_selection",
+                    label="Choose strategy to perform parameter fine-tuning",
+                    options=ModelSelection,
+                    value=ModelSelection.grid_search,
+                ),
+                DropdownField(
+                    name="model_selection_scoring",
+                    label="Select a scoring for identifying the best estimator following a grid search",
+                    options=ClassificationScoring,
+                    value=ClassificationScoring.accuracy,
+                ),
+                NumberField(
+                    name="n_estimators",
+                    label="The number of trees in the forest",
+                    min=1,
+                    step=1,
+                    value=100,
+                ),
+                MultiSelectField(
+                    name="criterion",
+                    label="The function to measure the quality of a split",
+                    options=ClusteringCriterion,
+                    value=ClusteringCriterion.gini,
+                ),
+                NumberField(
+                    name="max_depth",
+                    label="The maximum depth of the tree",
+                    min=1,
+                    value=1,
+                ),
+                NumberField(
+                    name="random_state",
+                    label="Seed for random number generation",
+                    min=0,
+                    max=4294967295,
+                    step=1,
+                    value=6,
+                ),
+            ]
+        )
+
     calc_method = staticmethod(random_forest)
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
@@ -752,6 +1469,127 @@ class ClassificationSVM(DataAnalysisStep):
         "y_test_df",
     ]
 
+    def create_form(self):
+        return Form(
+            label="Random Forest",
+            input_fields=[
+                DropdownField(
+                    name="input_df",
+                    label="Choose dataframe to be plotted",
+                    options=AnalysisLevel,
+                ),
+                # TODO: Add dynamic fill for labels_column & positive_label
+                DropdownField(
+                    name="labels_column",
+                    label="Choose labels column from metadata",
+                ),
+                DropdownField(
+                    name="positive_label",
+                    label="Choose positive class",
+                ),
+                NumberField(
+                    name="test_size",
+                    label="Test size",
+                    min=0,
+                    value=0.20,
+                ),
+                DropdownField(
+                    name="split_stratisfy",
+                    label="Stratify the split",
+                    options=YesNo,
+                    value=YesNo.yes,
+                ),
+                # TODO: Validation strategy
+                DropdownField(
+                    name="validation_strategy",
+                    label="Validation strategy",
+                    options=ClassificationValidationStrategy,
+                    value=ClassificationValidationStrategy.k_fold,
+                ),
+                NumberField(
+                    name="train_val_split",
+                    label="Choose the size of the validation data set (you can either enter the absolute number of validation "
+                          "samples or a number between 0.0 and 1.0 to represent the percentage of validation samples)",
+                    value=0.20,
+                ),
+                NumberField(
+                    name="n_splits",
+                    label="Number of folds",
+                    min=2,
+                    value=5,
+                ),
+                DropdownField(
+                    name="shuffle",
+                    label="Whether to shuffle the data before splitting into batches",
+                    options=YesNo,
+                    value=YesNo.yes,
+                ),
+                NumberField(
+                    name="n_repeats",
+                    label="Number of times cross-validator needs to be repeated",
+                    min=1,
+                    value=10,
+                ),
+                NumberField(
+                    name="random_state_cv",
+                    label="Seed for random number generation",
+                    min=0,
+                    max=4294967295,
+                    step=1,
+                    value=42,
+                ),
+                NumberField(
+                    name="p_samples",
+                    label="Size of the test sets",
+                    value=1,
+                ),
+                MultiSelectField(
+                    name="scoring",
+                    label="Scoring for the model",
+                    options=ClassificationScoring,
+                    value=ClassificationScoring.accuracy,
+                ),
+                DropdownField(
+                    name="model_selection",
+                    label="Choose strategy to perform parameter fine-tuning",
+                    options=ModelSelection,
+                    value=ModelSelection.grid_search,
+                ),
+                DropdownField(
+                    name="model_selection_scoring",
+                    label="Select a scoring for identifying the best estimator following a grid search",
+                    options=ClassificationScoring,
+                    value=ClassificationScoring.accuracy,
+                ),
+                NumberField(
+                    name="C",
+                    label="C: regularization parameter (the strength of the regularization is inversely proportional to C)",
+                    min=0.0,
+                    value=1.0,
+                ),
+                MultiSelectField(
+                    name="kernel",
+                    label="Specifies the kernel type to be used in the algorithm",
+                    options=ClassificationKernel,
+                    value=ClassificationKernel.linear,
+                ),
+                NumberField(
+                    name="tolerance",
+                    label="Tolerance for stopping criterion",
+                    min=0.0,
+                    value=1e-4,
+                ),
+                NumberField(
+                    name="random_state",
+                    label="Seed for random number generation",
+                    min=0.0,
+                    max=4294967295,
+                    step=1,
+                    value=6,
+                ),
+            ]
+        )
+
     calc_method = staticmethod(svm)
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
@@ -771,6 +1609,19 @@ class ModelEvaluationClassificationModel(DataAnalysisStep):
     ]
     output_keys = ["scores_df"]
 
+    def create_form(self):
+        return Form(
+            label="Evaluation of classification models",
+            input_fields=[
+                MultiSelectField(
+                    name="scoring",
+                    label="Scoring for the model",
+                    options=ClassificationScoring,
+                    value=ClassificationScoring.accuracy,
+                ),
+            ]
+        )
+
     def method(self, inputs: dict) -> dict:
         return evaluate_classification_model(**inputs)
 
@@ -787,6 +1638,60 @@ class DimensionReductionTSNE(DataAnalysisStep):
 
     output_keys = ["embedded_data"]
 
+    def create_form(self):
+        return Form(
+            label="t-SNE",
+            input_fields=[
+                DropdownField(
+                    name="input_df",
+                    label="Dimension reduction of a dataframe using t-SNE",
+                    options=AnalysisLevel,
+                ),
+                NumberField(
+                    name="n_components",
+                    label="Dimension of the embedded space",
+                    min=1,
+                    step=1,
+                    value=2,
+                ),
+                NumberField(
+                    name="perplexity",
+                    label="Perplexity",
+                    min=5.0,
+                    max=50.0,
+                    value=30.0,
+                ),
+                MultiSelectField(
+                    name="metric",
+                    label="Metric",
+                    options=DimensionReductionMetric,
+                    value=DimensionReductionMetric.euclidean,
+                ),
+                NumberField(
+                    name="random_state",
+                    label="Seed for random number generation",
+                    min=0,
+                    max=4294967295,
+                    step=1,
+                    value=6,
+                ),
+                NumberField(
+                    name="n_iter",
+                    label="Maximum number of iterations for the optimization",
+                    min=250,
+                    value=1000,
+                ),
+                NumberField(
+                    name="n_iter_without_progress",
+                    label="Maximum number of iterations without progress before we abort the optimization",
+                    min=250,
+                    step=1,
+                    value=300,
+                ),
+
+            ]
+        )
+
     calc_method = staticmethod(t_sne)
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
@@ -801,6 +1706,59 @@ class DimensionReductionUMAP(DataAnalysisStep):
     method_description = "Dimension reduction of a dataframe using UMAP"
 
     output_keys = ["embedded_data"]
+
+    def create_form(self):
+        return Form(
+            label="UMAP",
+            input_fields=[
+                DropdownField(
+                    name="input_df",
+                    label="Dimension reduction of a dataframe using UMAP",
+                    options=AnalysisLevel,
+                ),
+                NumberField(
+                    name="n_neighbors",
+                    label="The size of local neighborhood (in terms of number of neighboring sample points) used for manifold "
+                          "approximation",
+                    min=2,
+                    max=100,
+                    step=1,
+                    value=15,
+                ),
+                NumberField(
+                    name="n_components",
+                    label="Number of components",
+                    min=1,
+                    max=100,
+                    step=1,
+                    value=2,
+                ),
+                FloatField(
+                    name="min_dist",
+                    label="The effective minimum distance between embedded points",
+                    min=0.1,
+                    step=0.1,
+                    value=0.1,
+                ),
+                DropdownField(
+                    name="metric",
+                    label="Distance metric",
+                    options=DimensionReductionMetric,
+                ),
+                NumberField(
+                    name="random_state",
+                    label="Seed for random number generation",
+                    min=0,
+                    max=4294967295,
+                    step=1,
+                    value=42,
+                ),
+            ]
+        )
+    
+    def modify_form(self, form, run):
+        input_df_field = form["input_df"]
+        input_df_field.set_options(form_helper.get_choices_for_protein_df_steps(run))
 
     calc_method = staticmethod(umap)
 
@@ -824,6 +1782,34 @@ class ProteinGraphPeptidesToIsoform(DataAnalysisStep):
         "filtered_blocks",
     ]
 
+    def create_form(self):
+        return Form(
+            label="Peptides to Isoform",
+            input_fields=[
+                TextField(
+                    name="protein_ID",
+                    label="Protein ID",
+                    value="Enter the Uniprot-ID of the protein",
+                ),
+                NumberField(
+                    name="k",
+                    label="k-mer length",
+                    min=1,
+                    step=1,
+                    value=5,
+                ),
+                NumberField(
+                    name="allowed_mismatches",
+                    label="Number of allowed mismatched amino acids per peptide. For many allowed mismatches, this can take a "
+                          "long time.",
+                    min=0,
+                    step=1,
+                    value=2,
+                ),
+            ]
+        )
+
+
     calc_method = staticmethod(peptides_to_isoform)
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
@@ -841,6 +1827,18 @@ class ProteinGraphVariationGraph(DataAnalysisStep):
         "graph_path",
         "filtered_blocks",
     ]
+
+    def create_form(self):
+        return Form(
+            label="Protein Variation Graph",
+            input_fields=[
+                TextField(
+                    name="protein_ID",
+                    label="Protein ID",
+                    value="Enter the Uniprot-ID of the protein",
+                ),
+            ]
+        )
 
     calc_method = staticmethod(variation_graph)
 
@@ -864,6 +1862,61 @@ class FLEXIQuantLF(DataAnalysisStep):
 
     plot_method = staticmethod(flexiquant_lf)
 
+    def create_form(self):
+        return Form(
+            label="FLEXIQuant-LF",
+            input_fields=[
+                DropdownField(
+                    name="peptide_df",
+                    label="Peptide dataframe",
+                ),
+                DropdownField(
+                    name="grouping_column",
+                    label="Grouping column in metadata",
+                ),
+                DropdownField(
+                    name="reference_group",
+                    label="Reference group",
+                ),
+                DropdownField(
+                    name="protein_id",
+                    label="Protein ID",
+                ),
+                NumberField(
+                    name="num_init",
+                    label="Number of RANSAC initiations",
+                    min=1,
+                    max=60,
+                    step=1,
+                    value=30,
+                ),
+                FloatField(
+                    name="mod_cutoff",
+                    label="Modification cutoff",
+                    min=0,
+                    max=1,
+                    value=0.5,
+                )
+            ]
+        )
+    
+    def modify_form(self, form, run):
+        peptide_df_field = form["peptide_df"]
+        grouping_column_field = form["grouping_column"]
+        reference_group_field = form["reference_group"]
+        protein_id_field = form["protein_id"]
+
+        peptide_df_field.set_options(form_helper.get_choices(run, "peptide_df"))
+        grouping_column_field.set_options(form_helper.to_choices(run.steps.metadata_df.drop("Sample", axis=1).columns[1:]))
+
+        chosen_grouping_column = self.data.get("grouping_column", grouping_column_field.value)
+        reference_group_field.set_options(form_helper.to_choices(run.steps.metadata_df[chosen_grouping_column].unique()))
+
+        peptide_df_instance_id = self.data.get("peptide_df", peptide_df_field.value)
+        protein_id_field.set_options(form_helper.to_choices(
+            run.steps.get_step_output(Step, "peptide_df", peptide_df_instance_id)["Protein ID"].unique()
+        ))
+
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
         inputs["peptide_df"] = steps.get_step_output(
             Step, "peptide_df", inputs["peptide_df"]
@@ -871,7 +1924,7 @@ class FLEXIQuantLF(DataAnalysisStep):
 
         inputs["metadata_df"] = steps.metadata_df
 
-
+ 
 class SelectPeptidesForProtein(DataAnalysisStep):
     display_name = "Select Peptides of Protein"
     operation = "Peptide analysis"
@@ -880,6 +1933,74 @@ class SelectPeptidesForProtein(DataAnalysisStep):
     output_keys = [
         "peptide_df",
     ]
+
+    def create_form(self):
+        return Form(
+            label="Select Peptides of Protein",
+            input_fields=[
+                DropdownField(
+                    name="peptide_df",
+                    label="Step to use peptide dataframe from",
+                ),
+                DropdownField(
+                    name="auto_select",
+                    label="Automatically select most significant Protein",
+                    options=YesNo,
+                    value=YesNo.no,
+                ),
+                DropdownField(
+                    name="protein_list",
+                    label="Select a list of Proteins from which you want to choose your Proteins of Interest",
+                ),
+                DropdownField(
+                    name="sort_proteins",
+                    label="Sort Proteins by p-value (requires a list of Proteins from a Differential Expression Analysis to be selected)",
+                    options=YesNo,
+                    value=YesNo.no,
+                ),
+                MultiSelectField(
+                    name="protein_ids",
+                    label="Protein IDs",
+                )
+            ]
+        )
+
+    def modify_form(self, form, run):
+        peptide_df_field = form["peptide_df"]
+        auto_select_field = form["auto_select"]
+        sort_proteins_field = form["sort_proteins"]
+        protein_list_field = form["protein_list"]
+        protein_ids_field = form["protein_ids"]
+
+        peptide_df_field.set_options( form_helper.get_choices(run, "peptide_df", Step))
+        peptide_df_field.value = run.steps.get_instance_identifiers(DataPreprocessingStep, "peptide_df")[-1]
+
+        selected_auto_select = True if auto_select_field.value==YesNo.yes else False
+
+        protein_list_options = form_helper.to_choices([] if selected_auto_select else ["all proteins"])
+        protein_list_options.extend(form_helper.get_choices(run, "significant_proteins_df", DataAnalysisStep))
+        protein_list_field.set_options(protein_list_options)
+
+        chosen_list = protein_list_field.value
+        if not selected_auto_select:
+            #TODO: Enable toggling
+            if chosen_list == "all_proteins":
+                protein_ids_field.set_options(form_helper.to_choices(
+                    run.steps.get_step_output(Step, "protein_df")["Protein ID"].unique()
+                    ))
+            else:
+                if sort_proteins_field.value==YesNo.yes:
+                    protein_ids_field.set_options(form_helper.to_choices(
+                        run.steps.get_step_output(
+                            DataAnalysisStep, "significant_proteins_df", chosen_list
+                        ).sort_values(by="corrected_p_value")["Protein ID"].unique()
+                    ))
+                else:
+                    protein_ids_field.set_options(form_helper.to_choices(
+                        run.steps.get_step_output(
+                            DataAnalysisStep, "significant_proteins_df", chosen_list
+                        )["Protein ID"].unique()
+                    ))
 
     calc_method = staticmethod(select_peptides_of_protein)
 
@@ -916,6 +2037,29 @@ class PTMsPerSample(DataAnalysisStep):
         "ptm_df",
     ]
 
+    def create_form(self):
+        return Form(
+            label="PTMs per Sample",
+            input_fields=[
+                DropdownField(
+                    name="peptide_df",
+                    label="Peptide dataframe containing the peptides of a single protein"
+                )
+            ]
+        )
+    
+    def modify_form(self, form, run):
+        peptide_df_field = form["peptide_df"]
+
+        peptide_df_field.set_options(form_helper.get_choices(run, "peptide_df"))
+    
+        single_protein_peptides = run.steps.get_instance_identifiers(
+            SelectPeptidesForProtein, "peptide_df"
+        )
+
+        if single_protein_peptides:
+            peptide_df_field.value = single_protein_peptides[0]
+
     calc_method = staticmethod(ptms_per_sample)
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
@@ -934,6 +2078,29 @@ class PTMsProteinAndPerSample(DataAnalysisStep):
     output_keys = [
         "ptm_df",
     ]
+
+    def create_form(self):
+        return Form(
+            label="PTMs per Sample",
+            input_fields=[
+                DropdownField(
+                    name="peptide_df",
+                    label="Peptide dataframe containing the peptides of a single protein"
+                )
+            ]
+        )
+    
+    def modify_form(self, form, run):
+        peptide_df_field = form["peptide_df"]
+
+        peptide_df_field.set_options(form_helper.get_choices(run, "peptide_df"))
+    
+        single_protein_peptides = run.steps.get_instance_identifiers(
+            SelectPeptidesForProtein, "peptide_df"
+        )
+
+        if single_protein_peptides:
+            peptide_df_field.value = single_protein_peptides[0]
 
     calc_method = staticmethod(ptms_per_protein_and_sample)
 

--- a/backend/protzilla/methods/data_analysis.py
+++ b/backend/protzilla/methods/data_analysis.py
@@ -1471,7 +1471,7 @@ class ClassificationSVM(DataAnalysisStep):
 
     def create_form(self):
         return Form(
-            label="Random Forest",
+            label="Support Vector Machine",
             input_fields=[
                 DropdownField(
                     name="input_df",
@@ -1909,10 +1909,10 @@ class FLEXIQuantLF(DataAnalysisStep):
         peptide_df_field.set_options(form_helper.get_choices(run, "peptide_df"))
         grouping_column_field.set_options(form_helper.to_choices(run.steps.metadata_df.drop("Sample", axis=1).columns[1:]))
 
-        chosen_grouping_column = self.data.get("grouping_column", grouping_column_field.value)
+        chosen_grouping_column = grouping_column_field.value
         reference_group_field.set_options(form_helper.to_choices(run.steps.metadata_df[chosen_grouping_column].unique()))
 
-        peptide_df_instance_id = self.data.get("peptide_df", peptide_df_field.value)
+        peptide_df_instance_id = peptide_df_field.value
         protein_id_field.set_options(form_helper.to_choices(
             run.steps.get_step_output(Step, "peptide_df", peptide_df_instance_id)["Protein ID"].unique()
         ))
@@ -1996,11 +1996,11 @@ class SelectPeptidesForProtein(DataAnalysisStep):
                         ).sort_values(by="corrected_p_value")["Protein ID"].unique()
                     ))
                 else:
-                    protein_ids_field.set_options(form_helper.to_choices(
-                        run.steps.get_step_output(
-                            DataAnalysisStep, "significant_proteins_df", chosen_list
-                        )["Protein ID"].unique()
-                    ))
+                    significant_proteins = run.steps.get_step_output(DataAnalysisStep, "significant_proteins_df", chosen_list)
+                    if significant_proteins is not None:
+                        protein_ids_field.set_options(form_helper.to_choices(
+                            significant_proteins["Protein ID"].unique()
+                        ))
 
     calc_method = staticmethod(select_peptides_of_protein)
 
@@ -2081,7 +2081,7 @@ class PTMsProteinAndPerSample(DataAnalysisStep):
 
     def create_form(self):
         return Form(
-            label="PTMs per Sample",
+            label="PTMs per Sample and Protein",
             input_fields=[
                 DropdownField(
                     name="peptide_df",

--- a/backend/protzilla/methods/data_analysis.py
+++ b/backend/protzilla/methods/data_analysis.py
@@ -8,23 +8,37 @@ from backend.protzilla.data_analysis.clustering import (
     k_means,
 )
 from backend.protzilla.data_analysis.differential_expression_anova import anova
-from backend.protzilla.data_analysis.differential_expression_kruskal_wallis import kruskal_wallis_test_on_ptm_data, \
-    kruskal_wallis_test_on_intensity_data
-from backend.protzilla.data_analysis.differential_expression_linear_model import linear_model
+from backend.protzilla.data_analysis.differential_expression_kruskal_wallis import (
+    kruskal_wallis_test_on_ptm_data,
+    kruskal_wallis_test_on_intensity_data,
+)
+from backend.protzilla.data_analysis.differential_expression_linear_model import (
+    linear_model,
+)
 from backend.protzilla.data_analysis.differential_expression_mann_whitney import (
-    mann_whitney_test_on_intensity_data, mann_whitney_test_on_ptm_data)
+    mann_whitney_test_on_intensity_data,
+    mann_whitney_test_on_ptm_data,
+)
 from backend.protzilla.data_analysis.differential_expression_t_test import t_test
 from backend.protzilla.data_analysis.dimension_reduction import t_sne, umap
-from backend.protzilla.data_analysis.ptm_analysis import ptms_per_sample, \
-    ptms_per_protein_and_sample, select_peptides_of_protein
-from backend.protzilla.data_analysis.model_evaluation import evaluate_classification_model
+from backend.protzilla.data_analysis.ptm_analysis import (
+    ptms_per_sample,
+    ptms_per_protein_and_sample,
+    select_peptides_of_protein,
+)
+from backend.protzilla.data_analysis.model_evaluation import (
+    evaluate_classification_model,
+)
 from backend.protzilla.data_analysis.plots import (
     clustergram_plot,
     create_volcano_plot,
     prot_quant_plot,
     scatter_plot,
 )
-from backend.protzilla.data_analysis.protein_graphs import peptides_to_isoform, variation_graph
+from backend.protzilla.data_analysis.protein_graphs import (
+    peptides_to_isoform,
+    variation_graph,
+)
 from backend.protzilla.data_analysis.ptm_analysis import (
     select_peptides_of_protein,
     ptms_per_protein_and_sample,
@@ -32,7 +46,10 @@ from backend.protzilla.data_analysis.ptm_analysis import (
 )
 from backend.protzilla.data_analysis.ptm_quantification import flexiquant_lf
 from backend.protzilla.form import *
-from backend.protzilla.methods.data_preprocessing import TransformationLog, DataPreprocessingStep
+from backend.protzilla.methods.data_preprocessing import (
+    TransformationLog,
+    DataPreprocessingStep,
+)
 from backend.protzilla.steps import Plots, Step, StepManager
 
 
@@ -190,8 +207,7 @@ class DifferentialExpressionANOVA(DataAnalysisStep):
             label="ANOVA",
             input_fields=[
                 DropdownField(
-                    name="protein_df",
-                    label="Step to use protein intensities from"
+                    name="protein_df", label="Step to use protein intensities from"
                 ),
                 DropdownField(
                     name="multiple_testing_correction_method",
@@ -208,29 +224,26 @@ class DifferentialExpressionANOVA(DataAnalysisStep):
                     step=0.01,
                     separatePrefix="\u03B1",
                 ),
+                DropdownField(name="grouping", label="Grouping from metadata"),
                 DropdownField(
-                    name="grouping",
-                    label="Grouping from metadata"
+                    name="selected_groups", label="Select groups to perform ANOVA on"
                 ),
-                DropdownField(
-                    name="selected_groups",
-                    label="Select groups to perform ANOVA on"
-                ),
-            ]
+            ],
         )
-    
+
     def modify_form(self, form, run):
         protein_df_field = form["protein_df"]
         grouping_field = form["grouping"]
         selected_groups_field = form["selected_groups"]
 
         protein_df_field.set_options(form_helper.get_choices_for_protein_df_steps(run))
-        grouping_field.set_options(form_helper.get_choices_for_metadata_non_sample_columns(run))
+        grouping_field.set_options(
+            form_helper.get_choices_for_metadata_non_sample_columns(run)
+        )
         grouping = grouping_field.value
-        selected_groups_field.set_options(form_helper.to_choices(
-            run.steps.metadata_df[grouping].unique()
-        ))
-
+        selected_groups_field.set_options(
+            form_helper.to_choices(run.steps.metadata_df[grouping].unique())
+        )
 
     calc_method = staticmethod(anova)
 
@@ -298,7 +311,7 @@ class DifferentialExpressionTTest(DataAnalysisStep):
                 ),
             ],
         )
-    
+
     def modify_form(self, form, run):
         protein_field = form["protein_df"]
         grouping_field = form["grouping"]
@@ -306,27 +319,37 @@ class DifferentialExpressionTTest(DataAnalysisStep):
         group2_field = form["group2"]
 
         protein_field.set_options(form_helper.get_choices_for_protein_df_steps(run))
-        grouping_field.set_options(form_helper.get_choices_for_metadata_non_sample_columns(run))
+        grouping_field.set_options(
+            form_helper.get_choices_for_metadata_non_sample_columns(run)
+        )
 
-        if (grouping_field.options == []):
+        if grouping_field.options == []:
             return
-        
+
         grouping = grouping_field.value
 
         # Set choices for group1 field based on selected grouping
-        group1_field.set_options(form_helper.to_choices(run.steps.metadata_df[grouping].unique()))
+        group1_field.set_options(
+            form_helper.to_choices(run.steps.metadata_df[grouping].unique())
+        )
 
-        #set choices for group2 field based on selected grouping and group1
-        if (group1_field.value in run.steps.metadata_df[grouping].unique()):
-            group2_field.set_options([
-                Option(el, el)
-                for el in run.steps.metadata_df[grouping].unique()
-                if el != group1_field.value
-            ])
+        # set choices for group2 field based on selected grouping and group1
+        if group1_field.value in run.steps.metadata_df[grouping].unique():
+            group2_field.set_options(
+                [
+                    Option(el, el)
+                    for el in run.steps.metadata_df[grouping].unique()
+                    if el != group1_field.value
+                ]
+            )
         else:
-            group2_field.set_options(list(reversed(
-                form_helper.to_choices(run.steps.metadata_df[grouping].unique()))
-            ))
+            group2_field.set_options(
+                list(
+                    reversed(
+                        form_helper.to_choices(run.steps.metadata_df[grouping].unique())
+                    )
+                )
+            )
 
     calc_method = staticmethod(t_test)
 
@@ -382,7 +405,7 @@ class DifferentialExpressionLinearModel(DataAnalysisStep):
                     name="group2",
                     label="Group 2",
                 ),
-            ]
+            ],
         )
 
     def modify_form(self, form, run):
@@ -390,27 +413,37 @@ class DifferentialExpressionLinearModel(DataAnalysisStep):
         group1_field = form["group1"]
         group2_field = form["group2"]
 
-        grouping_field.set_options(form_helper.get_choices_for_metadata_non_sample_columns(run))
+        grouping_field.set_options(
+            form_helper.get_choices_for_metadata_non_sample_columns(run)
+        )
 
-        if (grouping_field.options == []):
+        if grouping_field.options == []:
             return
-        
+
         grouping = grouping_field.value
 
         # Set choices for group1 field based on selected grouping
-        group1_field.set_options(form_helper.to_choices(run.steps.metadata_df[grouping].unique()))
+        group1_field.set_options(
+            form_helper.to_choices(run.steps.metadata_df[grouping].unique())
+        )
 
-        #set choices for group2 field based on selected grouping and group1
-        if (group1_field.value in run.steps.metadata_df[grouping].unique()):
-            group2_field.set_options([
-                Option(el, el)
-                for el in run.steps.metadata_df[grouping].unique()
-                if el != group1_field.value
-            ])
+        # set choices for group2 field based on selected grouping and group1
+        if group1_field.value in run.steps.metadata_df[grouping].unique():
+            group2_field.set_options(
+                [
+                    Option(el, el)
+                    for el in run.steps.metadata_df[grouping].unique()
+                    if el != group1_field.value
+                ]
+            )
         else:
-            group2_field.set_options(list(reversed(
-                form_helper.to_choices(run.steps.metadata_df[grouping].unique()))
-            ))
+            group2_field.set_options(
+                list(
+                    reversed(
+                        form_helper.to_choices(run.steps.metadata_df[grouping].unique())
+                    )
+                )
+            )
 
     calc_method = staticmethod(linear_model)
 
@@ -424,8 +457,10 @@ class DifferentialExpressionLinearModel(DataAnalysisStep):
 class DifferentialExpressionMannWhitneyOnIntensity(DataAnalysisStep):
     display_name = "Mann-Whitney Test"
     operation = "differential_expression"
-    method_description = ("A function to conduct a Mann-Whitney U test between groups defined in the clinical data."
-                          "The p-values are corrected for multiple testing.")
+    method_description = (
+        "A function to conduct a Mann-Whitney U test between groups defined in the clinical data."
+        "The p-values are corrected for multiple testing."
+    )
 
     output_keys = [
         "differentially_expressed_proteins_df",
@@ -477,7 +512,7 @@ class DifferentialExpressionMannWhitneyOnIntensity(DataAnalysisStep):
                     name="group2",
                     label="Group 2",
                 ),
-            ]
+            ],
         )
 
     def modify_form(self, form, run):
@@ -487,33 +522,45 @@ class DifferentialExpressionMannWhitneyOnIntensity(DataAnalysisStep):
         group2_field = form["group2"]
 
         protein_field.set_options(form_helper.get_choices_for_protein_df_steps(run))
-        grouping_field.set_options(form_helper.get_choices_for_metadata_non_sample_columns(run))
+        grouping_field.set_options(
+            form_helper.get_choices_for_metadata_non_sample_columns(run)
+        )
 
-        if (grouping_field.options == []):
+        if grouping_field.options == []:
             return
-        
+
         grouping = grouping_field.value
 
         # Set choices for group1 field based on selected grouping
-        group1_field.set_options(form_helper.to_choices(run.steps.metadata_df[grouping].unique()))
+        group1_field.set_options(
+            form_helper.to_choices(run.steps.metadata_df[grouping].unique())
+        )
 
-        #set choices for group2 field based on selected grouping and group1
-        if (group1_field.value in run.steps.metadata_df[grouping].unique()):
-            group2_field.set_options([
-                Option(el, el)
-                for el in run.steps.metadata_df[grouping].unique()
-                if el != group1_field.value
-            ])
+        # set choices for group2 field based on selected grouping and group1
+        if group1_field.value in run.steps.metadata_df[grouping].unique():
+            group2_field.set_options(
+                [
+                    Option(el, el)
+                    for el in run.steps.metadata_df[grouping].unique()
+                    if el != group1_field.value
+                ]
+            )
         else:
-            group2_field.set_options(list(reversed(
-                form_helper.to_choices(run.steps.metadata_df[grouping].unique()))
-            ))
+            group2_field.set_options(
+                list(
+                    reversed(
+                        form_helper.to_choices(run.steps.metadata_df[grouping].unique())
+                    )
+                )
+            )
 
     calc_method = staticmethod(mann_whitney_test_on_intensity_data)
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
         if steps.get_step_output(Step, "protein_df", inputs["protein_df"]) is not None:
-            inputs["protein_df"] = steps.get_step_output(Step, "protein_df", inputs["protein_df"])
+            inputs["protein_df"] = steps.get_step_output(
+                Step, "protein_df", inputs["protein_df"]
+            )
         inputs["metadata_df"] = steps.metadata_df
         inputs["log_base"] = steps.get_step_input(TransformationLog, "log_base")
         return inputs
@@ -522,8 +569,10 @@ class DifferentialExpressionMannWhitneyOnIntensity(DataAnalysisStep):
 class DifferentialExpressionMannWhitneyOnPTM(DataAnalysisStep):
     display_name = "Mann-Whitney Test"
     operation = "Peptide analysis"
-    method_description = ("A function to conduct a Mann-Whitney U test between groups defined in the clinical data."
-                          "The p-values are corrected for multiple testing.")
+    method_description = (
+        "A function to conduct a Mann-Whitney U test between groups defined in the clinical data."
+        "The p-values are corrected for multiple testing."
+    )
 
     output_keys = [
         "differentially_expressed_ptm_df",
@@ -575,7 +624,7 @@ class DifferentialExpressionMannWhitneyOnPTM(DataAnalysisStep):
                     name="group2",
                     label="Group 2",
                 ),
-            ]
+            ],
         )
 
     def modify_form(self, form, run):
@@ -584,28 +633,42 @@ class DifferentialExpressionMannWhitneyOnPTM(DataAnalysisStep):
         group1_field = form["group1"]
         group2_field = form["group2"]
 
-        ptm_df_field.set_options(form_helper.to_choices(run.steps.get_instance_identifiers(PTMsPerSample, "ptm_df")))
-        grouping_field.set_options(form_helper.get_choices_for_metadata_non_sample_columns(run))
+        ptm_df_field.set_options(
+            form_helper.to_choices(
+                run.steps.get_instance_identifiers(PTMsPerSample, "ptm_df")
+            )
+        )
+        grouping_field.set_options(
+            form_helper.get_choices_for_metadata_non_sample_columns(run)
+        )
 
-        if (grouping_field.options == []):
+        if grouping_field.options == []:
             return
-        
+
         grouping = grouping_field.value
 
         # Set choices for group1 field based on selected grouping
-        group1_field.set_options(form_helper.to_choices(run.steps.metadata_df[grouping].unique()))
+        group1_field.set_options(
+            form_helper.to_choices(run.steps.metadata_df[grouping].unique())
+        )
 
-        #set choices for group2 field based on selected grouping and group1
-        if (group1_field.value in run.steps.metadata_df[grouping].unique()):
-            group2_field.set_options([
-                Option(el, el)
-                for el in run.steps.metadata_df[grouping].unique()
-                if el != group1_field.value
-            ])
+        # set choices for group2 field based on selected grouping and group1
+        if group1_field.value in run.steps.metadata_df[grouping].unique():
+            group2_field.set_options(
+                [
+                    Option(el, el)
+                    for el in run.steps.metadata_df[grouping].unique()
+                    if el != group1_field.value
+                ]
+            )
         else:
-            group2_field.set_options(list(reversed(
-                form_helper.to_choices(run.steps.metadata_df[grouping].unique()))
-            ))
+            group2_field.set_options(
+                list(
+                    reversed(
+                        form_helper.to_choices(run.steps.metadata_df[grouping].unique())
+                    )
+                )
+            )
 
     calc_method = staticmethod(mann_whitney_test_on_ptm_data)
 
@@ -618,8 +681,10 @@ class DifferentialExpressionMannWhitneyOnPTM(DataAnalysisStep):
 class DifferentialExpressionKruskalWallisOnIntensity(DataAnalysisStep):
     display_name = "Kruskal-Wallis Test"
     operation = "differential_expression"
-    method_description = ("A function to conduct a Kruskal-Wallis test between groups defined in the clinical data."
-                          "The p-values are corrected for multiple testing.")
+    method_description = (
+        "A function to conduct a Kruskal-Wallis test between groups defined in the clinical data."
+        "The p-values are corrected for multiple testing."
+    )
 
     output_keys = [
         "differentially_expressed_proteins_df",
@@ -632,10 +697,7 @@ class DifferentialExpressionKruskalWallisOnIntensity(DataAnalysisStep):
         return Form(
             label="Kruskal-Wallis Test",
             input_fields=[
-                DropdownField(
-                    name="protein_df",
-                    label="Step to use protein data from"
-                ),
+                DropdownField(name="protein_df", label="Step to use protein data from"),
                 DropdownField(
                     name="multiple_testing_correction_method",
                     label="Multiple testing correction",
@@ -651,28 +713,27 @@ class DifferentialExpressionKruskalWallisOnIntensity(DataAnalysisStep):
                     step=0.01,
                     separatePrefix="\u03B1",
                 ),
-                DropdownField(
-                    name="grouping",
-                    label="Grouping from metadata"
-                ),
+                DropdownField(name="grouping", label="Grouping from metadata"),
                 DropdownField(
                     name="selected_groups",
-                    label="Select groups to perform Kruskal-Wallis Test on"
+                    label="Select groups to perform Kruskal-Wallis Test on",
                 ),
-            ]
+            ],
         )
-    
+
     def modify_form(self, form, run):
         protein_df_field = form["protein_df"]
         grouping_field = form["grouping"]
         selected_groups_field = form["selected_groups"]
 
         protein_df_field.set_options(form_helper.get_choices_for_protein_df_steps(run))
-        grouping_field.set_options(form_helper.get_choices_for_metadata_non_sample_columns(run))
+        grouping_field.set_options(
+            form_helper.get_choices_for_metadata_non_sample_columns(run)
+        )
         grouping = grouping_field.value
-        selected_groups_field.set_options(form_helper.to_choices(
-            run.steps.metadata_df[grouping].unique()
-        ))
+        selected_groups_field.set_options(
+            form_helper.to_choices(run.steps.metadata_df[grouping].unique())
+        )
 
     calc_method = staticmethod(kruskal_wallis_test_on_intensity_data)
 
@@ -685,8 +746,10 @@ class DifferentialExpressionKruskalWallisOnIntensity(DataAnalysisStep):
 class DifferentialExpressionKruskalWallisOnPTM(DataAnalysisStep):
     display_name = "Kruskal-Wallis Test"
     operation = "Peptide analysis"
-    method_description = ("A function to conduct a Kruskal-Wallis test between groups defined in the clinical data."
-                          "The p-values are corrected for multiple testing.")
+    method_description = (
+        "A function to conduct a Kruskal-Wallis test between groups defined in the clinical data."
+        "The p-values are corrected for multiple testing."
+    )
 
     output_keys = [
         "differentially_expressed_ptm_df",
@@ -699,10 +762,7 @@ class DifferentialExpressionKruskalWallisOnPTM(DataAnalysisStep):
         return Form(
             label="Kruskal-Wallis Test",
             input_fields=[
-                DropdownField(
-                    name="ptm_df",
-                    label="Step to use ptm data from"
-                ),
+                DropdownField(name="ptm_df", label="Step to use ptm data from"),
                 DropdownField(
                     name="multiple_testing_correction_method",
                     label="Multiple testing correction",
@@ -718,30 +778,31 @@ class DifferentialExpressionKruskalWallisOnPTM(DataAnalysisStep):
                     step=0.01,
                     separatePrefix="\u03B1",
                 ),
-                DropdownField(
-                    name="grouping",
-                    label="Grouping from metadata"
-                ),
+                DropdownField(name="grouping", label="Grouping from metadata"),
                 DropdownField(
                     name="selected_groups",
-                    label="Select groups to perform Kruskal-Wallis Test on"
+                    label="Select groups to perform Kruskal-Wallis Test on",
                 ),
-            ]
+            ],
         )
-    
+
     def modify_form(self, form, run):
         ptm_df_field = form["ptm_df"]
         grouping_field = form["grouping"]
         selected_groups_field = form["selected_groups"]
 
-        ptm_df_field.set_options(form_helper.to_choices(
-            run.steps.get_instance_identifiers(PTMsPerSample, "ptm_df")
-        ))
-        grouping_field.set_options(form_helper.get_choices_for_metadata_non_sample_columns(run))
+        ptm_df_field.set_options(
+            form_helper.to_choices(
+                run.steps.get_instance_identifiers(PTMsPerSample, "ptm_df")
+            )
+        )
+        grouping_field.set_options(
+            form_helper.get_choices_for_metadata_non_sample_columns(run)
+        )
         grouping = grouping_field.value
-        selected_groups_field.set_options(form_helper.to_choices(
-            run.steps.metadata_df[grouping].unique()
-        ))
+        selected_groups_field.set_options(
+            form_helper.to_choices(run.steps.metadata_df[grouping].unique())
+        )
 
     calc_method = staticmethod(kruskal_wallis_test_on_ptm_data)
 
@@ -754,10 +815,12 @@ class DifferentialExpressionKruskalWallisOnPTM(DataAnalysisStep):
 class PlotVolcano(DataAnalysisStep):
     display_name = "Volcano Plot"
     operation = "plot"
-    method_description = ("Plots the results of a differential expression analysis in a volcano plot. The x-axis shows "
-                          "the log2 fold change and the y-axis shows the -log10 of the corrected p-values. The user "
-                          "can define a fold change threshold and an alpha level to highlight significant items.")
-    
+    method_description = (
+        "Plots the results of a differential expression analysis in a volcano plot. The x-axis shows "
+        "the log2 fold change and the y-axis shows the -log10 of the corrected p-values. The user "
+        "can define a fold change threshold and an alpha level to highlight significant items."
+    )
+
     output_keys = []
 
     def create_form(self):
@@ -778,10 +841,10 @@ class PlotVolcano(DataAnalysisStep):
                 MultiSelectField(
                     name="items_of_interest",
                     label="Items of interest (will be highlighted)",
-                )
+                ),
             ],
         )
-    
+
     def modify_form(self, form, run):
         input_dict_field = form["input_dict"]
         items_of_interest_field = form["items_of_interest"]
@@ -789,12 +852,13 @@ class PlotVolcano(DataAnalysisStep):
         input_dict_field.set_options(
             form_helper.to_choices(
                 run.steps.get_instance_identifiers(
-                    Step, ["corrected_p_values_df", "log2_fold_change_df"],
+                    Step,
+                    ["corrected_p_values_df", "log2_fold_change_df"],
                 )
             )
         )
 
-        if(input_dict_field.value == None):
+        if input_dict_field.value == None:
             return
 
         input_dict_instance_id = input_dict_field.value
@@ -840,34 +904,36 @@ class PlotVolcano(DataAnalysisStep):
 
 class PlotScatterPlot(DataAnalysisStep):
     display_name = "Scatter Plot"
-    operation = "plot" 
+    operation = "plot"
     method_description = "Creates a scatter plot from data. This requires a dimension reduction method to be run first, as the input dataframe should contain only 2 or 3 columns."
 
     plot_method = staticmethod(scatter_plot)
 
     def create_form(self):
         return Form(
-            label = "Scatter Plot",
+            label="Scatter Plot",
             input_fields=[
                 DropdownField(
-                    name = "input_df",
-                    label = "Choose dataframe to be plotted",
+                    name="input_df",
+                    label="Choose dataframe to be plotted",
                 ),
-                #TODO: handle isRequired
+                # TODO: handle isRequired
                 DropdownField(
-                    name = "color_df",
-                    label = "Choose dataframe to be used for coloring",
+                    name="color_df",
+                    label="Choose dataframe to be used for coloring",
                 ),
             ],
         )
-    
+
     def modify_form(self, form, run):
         input_df_field = form["input_df"]
         color_field = form["color_df"]
 
         input_df_field.set_options(
             form_helper.to_choices(
-                run.steps.get_instance_identifiers(DimensionReductionUMAP, "embedded_data")
+                run.steps.get_instance_identifiers(
+                    DimensionReductionUMAP, "embedded_data"
+                )
             )
         )
 
@@ -875,7 +941,7 @@ class PlotScatterPlot(DataAnalysisStep):
             form_helper.to_choices(
                 run.steps.get_instance_identifiers(Step, "color_df"), required=False
             )
-        ) 
+        )
 
     # TODO: input
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
@@ -893,7 +959,7 @@ class PlotClustergram(DataAnalysisStep):
 
     plot_method = staticmethod(clustergram_plot)
 
-    #TODO: handle isRequired with sample_group_df
+    # TODO: handle isRequired with sample_group_df
     def create_form(self):
         return Form(
             label="Clustergram",
@@ -913,9 +979,9 @@ class PlotClustergram(DataAnalysisStep):
                     options=YesNo,
                     value=YesNo.no,
                 ),
-            ]
+            ],
         )
-    
+
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
         inputs["input_df"] = steps.protein_df
         inputs["sample_group_df"] = steps.metadata_df
@@ -963,21 +1029,21 @@ class PlotProtQuant(DataAnalysisStep):
         )
 
     def modify_form(self, form, run):
-        form["input_df"].set_options(form_helper.get_choices_for_protein_df_steps(
-            run
-        ))
+        form["input_df"].set_options(form_helper.get_choices_for_protein_df_steps(run))
 
-        if (form["input_df"].options):
-            if (not form["input_df"].value):
+        if form["input_df"].options:
+            if not form["input_df"].value:
                 form["input_df"].value = form["input_df"].options[0].label
 
-            form["protein_group"].set_options(form_helper.to_choices(
-                run.steps.get_step_output(
-                    step_type=Step,
-                    output_key="protein_df",
-                    instance_identifier=form["input_df"].value,
-                )["Protein ID"].unique()
-            ))
+            form["protein_group"].set_options(
+                form_helper.to_choices(
+                    run.steps.get_step_output(
+                        step_type=Step,
+                        output_key="protein_df",
+                        instance_identifier=form["input_df"].value,
+                    )["Protein ID"].unique()
+                )
+            )
 
         if form["similarity_measure"].value == SimilarityMeasure.cosine_similarity:
             form["similarity"] = FloatField(
@@ -997,7 +1063,6 @@ class PlotProtQuant(DataAnalysisStep):
                 max=999,
                 step=1,
             )
-        
 
     plot_method = staticmethod(prot_quant_plot)
 
@@ -1126,9 +1191,7 @@ class ClusteringKMeans(DataAnalysisStep):
                     min=0,
                     value=1e-4,
                 ),
-
-
-            ]
+            ],
         )
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
@@ -1221,8 +1284,8 @@ class ClusteringExpectationMaximisation(DataAnalysisStep):
                     max=4294967295,
                     step=1,
                     value=0,
-                )
-            ]
+                ),
+            ],
         )
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
@@ -1299,8 +1362,8 @@ class ClusteringHierarchicalAgglomerative(DataAnalysisStep):
                     label="The linkage criterion to use in order to to determine the distance to use between sets of observation",
                     options=ClusteringLinkage,
                     value=ClusteringLinkage.ward,
-                )
-            ]
+                ),
+            ],
         )
 
     calc_method = staticmethod(hierarchical_agglomerative_clustering)
@@ -1365,7 +1428,7 @@ class ClassificationRandomForest(DataAnalysisStep):
                 NumberField(
                     name="train_val_split",
                     label="Choose the size of the validation data set (you can either enter the absolute number of validation "
-                          "samples or a number between 0.0 and 1.0 to represent the percentage of validation samples)",
+                    "samples or a number between 0.0 and 1.0 to represent the percentage of validation samples)",
                     value=0.20,
                 ),
                 NumberField(
@@ -1444,7 +1507,7 @@ class ClassificationRandomForest(DataAnalysisStep):
                     step=1,
                     value=6,
                 ),
-            ]
+            ],
         )
 
     calc_method = staticmethod(random_forest)
@@ -1509,7 +1572,7 @@ class ClassificationSVM(DataAnalysisStep):
                 NumberField(
                     name="train_val_split",
                     label="Choose the size of the validation data set (you can either enter the absolute number of validation "
-                          "samples or a number between 0.0 and 1.0 to represent the percentage of validation samples)",
+                    "samples or a number between 0.0 and 1.0 to represent the percentage of validation samples)",
                     value=0.20,
                 ),
                 NumberField(
@@ -1587,7 +1650,7 @@ class ClassificationSVM(DataAnalysisStep):
                     step=1,
                     value=6,
                 ),
-            ]
+            ],
         )
 
     calc_method = staticmethod(svm)
@@ -1619,7 +1682,7 @@ class ModelEvaluationClassificationModel(DataAnalysisStep):
                     options=ClassificationScoring,
                     value=ClassificationScoring.accuracy,
                 ),
-            ]
+            ],
         )
 
     def method(self, inputs: dict) -> dict:
@@ -1688,8 +1751,7 @@ class DimensionReductionTSNE(DataAnalysisStep):
                     step=1,
                     value=300,
                 ),
-
-            ]
+            ],
         )
 
     calc_method = staticmethod(t_sne)
@@ -1719,7 +1781,7 @@ class DimensionReductionUMAP(DataAnalysisStep):
                 NumberField(
                     name="n_neighbors",
                     label="The size of local neighborhood (in terms of number of neighboring sample points) used for manifold "
-                          "approximation",
+                    "approximation",
                     min=2,
                     max=100,
                     step=1,
@@ -1753,9 +1815,9 @@ class DimensionReductionUMAP(DataAnalysisStep):
                     step=1,
                     value=42,
                 ),
-            ]
+            ],
         )
-    
+
     def modify_form(self, form, run):
         input_df_field = form["input_df"]
         input_df_field.set_options(form_helper.get_choices_for_protein_df_steps(run))
@@ -1801,14 +1863,13 @@ class ProteinGraphPeptidesToIsoform(DataAnalysisStep):
                 NumberField(
                     name="allowed_mismatches",
                     label="Number of allowed mismatched amino acids per peptide. For many allowed mismatches, this can take a "
-                          "long time.",
+                    "long time.",
                     min=0,
                     step=1,
                     value=2,
                 ),
-            ]
+            ],
         )
-
 
     calc_method = staticmethod(peptides_to_isoform)
 
@@ -1837,7 +1898,7 @@ class ProteinGraphVariationGraph(DataAnalysisStep):
                     label="Protein ID",
                     value="Enter the Uniprot-ID of the protein",
                 ),
-            ]
+            ],
         )
 
     calc_method = staticmethod(variation_graph)
@@ -1896,10 +1957,10 @@ class FLEXIQuantLF(DataAnalysisStep):
                     min=0,
                     max=1,
                     value=0.5,
-                )
-            ]
+                ),
+            ],
         )
-    
+
     def modify_form(self, form, run):
         peptide_df_field = form["peptide_df"]
         grouping_column_field = form["grouping_column"]
@@ -1907,15 +1968,27 @@ class FLEXIQuantLF(DataAnalysisStep):
         protein_id_field = form["protein_id"]
 
         peptide_df_field.set_options(form_helper.get_choices(run, "peptide_df"))
-        grouping_column_field.set_options(form_helper.to_choices(run.steps.metadata_df.drop("Sample", axis=1).columns[1:]))
+        grouping_column_field.set_options(
+            form_helper.to_choices(
+                run.steps.metadata_df.drop("Sample", axis=1).columns[1:]
+            )
+        )
 
         chosen_grouping_column = grouping_column_field.value
-        reference_group_field.set_options(form_helper.to_choices(run.steps.metadata_df[chosen_grouping_column].unique()))
+        reference_group_field.set_options(
+            form_helper.to_choices(
+                run.steps.metadata_df[chosen_grouping_column].unique()
+            )
+        )
 
         peptide_df_instance_id = peptide_df_field.value
-        protein_id_field.set_options(form_helper.to_choices(
-            run.steps.get_step_output(Step, "peptide_df", peptide_df_instance_id)["Protein ID"].unique()
-        ))
+        protein_id_field.set_options(
+            form_helper.to_choices(
+                run.steps.get_step_output(Step, "peptide_df", peptide_df_instance_id)[
+                    "Protein ID"
+                ].unique()
+            )
+        )
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
         inputs["peptide_df"] = steps.get_step_output(
@@ -1924,7 +1997,7 @@ class FLEXIQuantLF(DataAnalysisStep):
 
         inputs["metadata_df"] = steps.metadata_df
 
- 
+
 class SelectPeptidesForProtein(DataAnalysisStep):
     display_name = "Select Peptides of Protein"
     operation = "Peptide analysis"
@@ -1961,8 +2034,8 @@ class SelectPeptidesForProtein(DataAnalysisStep):
                 MultiSelectField(
                     name="protein_ids",
                     label="Protein IDs",
-                )
-            ]
+                ),
+            ],
         )
 
     def modify_form(self, form, run):
@@ -1972,35 +2045,53 @@ class SelectPeptidesForProtein(DataAnalysisStep):
         protein_list_field = form["protein_list"]
         protein_ids_field = form["protein_ids"]
 
-        peptide_df_field.set_options( form_helper.get_choices(run, "peptide_df", Step))
-        peptide_df_field.value = run.steps.get_instance_identifiers(DataPreprocessingStep, "peptide_df")[-1]
+        peptide_df_field.set_options(form_helper.get_choices(run, "peptide_df", Step))
+        peptide_df_field.value = run.steps.get_instance_identifiers(
+            DataPreprocessingStep, "peptide_df"
+        )[-1]
 
-        selected_auto_select = True if auto_select_field.value==YesNo.yes else False
+        selected_auto_select = True if auto_select_field.value == YesNo.yes else False
 
-        protein_list_options = form_helper.to_choices([] if selected_auto_select else ["all proteins"])
-        protein_list_options.extend(form_helper.get_choices(run, "significant_proteins_df", DataAnalysisStep))
+        protein_list_options = form_helper.to_choices(
+            [] if selected_auto_select else ["all proteins"]
+        )
+        protein_list_options.extend(
+            form_helper.get_choices(run, "significant_proteins_df", DataAnalysisStep)
+        )
         protein_list_field.set_options(protein_list_options)
 
         chosen_list = protein_list_field.value
         if not selected_auto_select:
-            #TODO: Enable toggling
+            # TODO: Enable toggling
             if chosen_list == "all_proteins":
-                protein_ids_field.set_options(form_helper.to_choices(
-                    run.steps.get_step_output(Step, "protein_df")["Protein ID"].unique()
-                    ))
+                protein_ids_field.set_options(
+                    form_helper.to_choices(
+                        run.steps.get_step_output(Step, "protein_df")[
+                            "Protein ID"
+                        ].unique()
+                    )
+                )
             else:
-                if sort_proteins_field.value==YesNo.yes:
-                    protein_ids_field.set_options(form_helper.to_choices(
-                        run.steps.get_step_output(
-                            DataAnalysisStep, "significant_proteins_df", chosen_list
-                        ).sort_values(by="corrected_p_value")["Protein ID"].unique()
-                    ))
+                if sort_proteins_field.value == YesNo.yes:
+                    protein_ids_field.set_options(
+                        form_helper.to_choices(
+                            run.steps.get_step_output(
+                                DataAnalysisStep, "significant_proteins_df", chosen_list
+                            )
+                            .sort_values(by="corrected_p_value")["Protein ID"]
+                            .unique()
+                        )
+                    )
                 else:
-                    significant_proteins = run.steps.get_step_output(DataAnalysisStep, "significant_proteins_df", chosen_list)
+                    significant_proteins = run.steps.get_step_output(
+                        DataAnalysisStep, "significant_proteins_df", chosen_list
+                    )
                     if significant_proteins is not None:
-                        protein_ids_field.set_options(form_helper.to_choices(
-                            significant_proteins["Protein ID"].unique()
-                        ))
+                        protein_ids_field.set_options(
+                            form_helper.to_choices(
+                                significant_proteins["Protein ID"].unique()
+                            )
+                        )
 
     calc_method = staticmethod(select_peptides_of_protein)
 
@@ -2012,17 +2103,23 @@ class SelectPeptidesForProtein(DataAnalysisStep):
         inputs["metadata_df"] = steps.metadata_df
 
         if inputs["auto_select"]:
-            significant_proteins = (
-                steps.get_step_output(DataAnalysisStep, "significant_proteins_df", inputs["protein_list"]))
-            index_of_most_significant_protein = significant_proteins['corrected_p_value'].idxmin()
-            most_significant_protein = significant_proteins.loc[index_of_most_significant_protein]
+            significant_proteins = steps.get_step_output(
+                DataAnalysisStep, "significant_proteins_df", inputs["protein_list"]
+            )
+            index_of_most_significant_protein = significant_proteins[
+                "corrected_p_value"
+            ].idxmin()
+            most_significant_protein = significant_proteins.loc[
+                index_of_most_significant_protein
+            ]
             inputs["protein_id"] = [most_significant_protein["Protein ID"]]
-            self.messages.append({
-                "level": logging.INFO,
-                "msg":
-                    f"Selected the most significant Protein: {most_significant_protein['Protein ID']}, "
-                    f"from {inputs['protein_list']}"
-            })
+            self.messages.append(
+                {
+                    "level": logging.INFO,
+                    "msg": f"Selected the most significant Protein: {most_significant_protein['Protein ID']}, "
+                    f"from {inputs['protein_list']}",
+                }
+            )
 
         return inputs
 
@@ -2030,8 +2127,10 @@ class SelectPeptidesForProtein(DataAnalysisStep):
 class PTMsPerSample(DataAnalysisStep):
     display_name = "PTMs per Sample"
     operation = "Peptide analysis"
-    method_description = ("Analyze the post-translational modifications (PTMs) of a single protein of interest. "
-                          "This function requires a peptide dataframe with PTM information.")
+    method_description = (
+        "Analyze the post-translational modifications (PTMs) of a single protein of interest. "
+        "This function requires a peptide dataframe with PTM information."
+    )
 
     output_keys = [
         "ptm_df",
@@ -2043,16 +2142,16 @@ class PTMsPerSample(DataAnalysisStep):
             input_fields=[
                 DropdownField(
                     name="peptide_df",
-                    label="Peptide dataframe containing the peptides of a single protein"
+                    label="Peptide dataframe containing the peptides of a single protein",
                 )
-            ]
+            ],
         )
-    
+
     def modify_form(self, form, run):
         peptide_df_field = form["peptide_df"]
 
         peptide_df_field.set_options(form_helper.get_choices(run, "peptide_df"))
-    
+
         single_protein_peptides = run.steps.get_instance_identifiers(
             SelectPeptidesForProtein, "peptide_df"
         )
@@ -2072,8 +2171,10 @@ class PTMsPerSample(DataAnalysisStep):
 class PTMsProteinAndPerSample(DataAnalysisStep):
     display_name = "PTMs per Sample and Protein"
     operation = "Peptide analysis"
-    method_description = ("Analyze the post-translational modifications (PTMs) of all Proteins. "
-                          "This function requires a peptide dataframe with PTM information.")
+    method_description = (
+        "Analyze the post-translational modifications (PTMs) of all Proteins. "
+        "This function requires a peptide dataframe with PTM information."
+    )
 
     output_keys = [
         "ptm_df",
@@ -2085,16 +2186,16 @@ class PTMsProteinAndPerSample(DataAnalysisStep):
             input_fields=[
                 DropdownField(
                     name="peptide_df",
-                    label="Peptide dataframe containing the peptides of a single protein"
+                    label="Peptide dataframe containing the peptides of a single protein",
                 )
-            ]
+            ],
         )
-    
+
     def modify_form(self, form, run):
         peptide_df_field = form["peptide_df"]
 
         peptide_df_field.set_options(form_helper.get_choices(run, "peptide_df"))
-    
+
         single_protein_peptides = run.steps.get_instance_identifiers(
             SelectPeptidesForProtein, "peptide_df"
         )


### PR DESCRIPTION
## Description
fixes #98
Adds forms to all classes without a form defined.

## Changes
All changes are made in [data_analysis.py](https://github.com/cschlaffner/PROTzilla/blob/form-analysis/backend/protzilla/methods/data_analysis.py). For every class that had its input defined create_form() and if needed a modify_form() were added. 
Other TODO's regarding the input flow are not solved with this pull request and are subject for another issue.

## Testing
Open Protzilla 2 (on the main branch) and Protzilla 1 on the form-definition branch. Then for each step in Data Analysis test wether the forms are working on Protzilla 1 (loading correctly and not throwing error in the terminal) and do not differ from the forms on Protzilla 2.

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [x] At least one other developer reviewed and approved the changes
