### PR TITLE
fix #101

### DIFF
--- a/backend/protzilla/methods/data_preprocessing.py
+++ b/backend/protzilla/methods/data_preprocessing.py
@@ -150,17 +150,18 @@ class FilterPeptidesByPEPThreshold(DataPreprocessingStep):
     display_name = "PEP threshold"
     operation = "filter_peptides"
     method_description = "Filter by PEP-threshold"
-    output_keys = ["protein_df", "peptide_df", "filtered_peptides"]
+    output_keys = ["peptide_df", "filtered_peptides"]
 
     def create_form(self):
         return Form(
             label="Filter peptides by PEP threshold",
             input_fields=[
                 FloatField(
-                    name="treshold",
+                    name="threshold",
                     label="Threshold value for PEP",
                     value=0,
                     min=0,
+                    max=1,
                     step=0.1,
                     hasStepButtons=True,
                 ),


### PR DESCRIPTION
## Description  
Fixes #101.  
This PR corrects the PEP threshold input field in the *Filter Peptides by PEP Threshold* step.  
A typo in the field name (`treshold`) prevented the backend from receiving the expected parameter `threshold`, causing a validation error even when entering valid values.  
Additionally, the threshold field now correctly enforces an upper limit of `1.0`.

## Changes  
- Fixed typo: renamed form input from `treshold` -> `threshold` so it matches backend expectations.  
- Added missing `max=1` constraint to the threshold field.  
- Updated `output_keys` to remove unused `protein_df`, preventing output-validation errors.

## Testing  
1. Go to **Data Preprocessing -> Filter Peptides -> PEP Threshold**.  
2. Enter a valid float between `0` and `1` (e.g., `0.05`).  
3. Click **Calculate**.  
4. Confirm that no validation error appears and the step completes successfully.  
5. Optionally test with invalid values (e.g., `1.5`) to verify the UI blocks them.
 
**Code review**
- [x] I have self-reviewed my code.
- [x] At least one other developer reviewed and approved the changes
