### PR TITLE
Fixed #104 by returning None instead of an empty dataframe

### DIFF
--- a/backend/protzilla/data_preprocessing/normalisation.py
+++ b/backend/protzilla/data_preprocessing/normalisation.py
@@ -201,7 +201,7 @@ def by_reference_protein(
     else:
         msg = "The protein was not found"
         return dict(
-            protein_df=scaled_df,
+            protein_df=None,
             dropped_samples=None,
             messages=[dict(level=logging.ERROR, msg=msg)],
         )

--- a/backend/protzilla/steps.py
+++ b/backend/protzilla/steps.py
@@ -171,7 +171,7 @@ class Step:
     def handle_calc_outputs(self, outputs: dict) -> None:
         """
         Handles the dictionary from the calculation method and creates an Output object from it.
-        Responsible for checking that the output is a dictonary and not empty, and setting the output attribute of the instance.
+        Responsible for checking that the output is a dictionary and not empty, and setting the output attribute of the instance.
 
         :param outputs: A dictionary received after the calculation
         :return: None


### PR DESCRIPTION
## Description
fixes #104
<!-- Description of the change made in the pull-request. -->

## Changes
The  `by_reference_protein` now returns None instead of an empty dataframe, so that `handle_calc_outputs` correctly throws an error.

## Testing
When entering a valid ID (e.g., A0A0C4DH38) the step succeeds.
When entering an invalid ID (e.g., THISISNOTAPROTEIN) the step throws an error and doesnt succeed.
 
**Code review**
- [x] I have self-reviewed my code.
- [x] At least one other developer reviewed and approved the changes
