### PR TITLE
Add current_step_has_plot flag and improve plot placeholder message

### DIFF
--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -392,7 +392,7 @@ def get_run_data(request):
             run_data["current_section"] = run.current_step.section
             run_data["current_step_index"] = run.steps.current_step_index
             run_data["memory_usage"] = get_memory_usage()
-            run_data["current_step_has_plot"] = bool(run.current_step.plot_method)
+            run_data["current_step_has_plot"] = True if run.current_step.plot_method is not None else False
         else:
             run_data["displayed_steps"] = []
             run_data["current_section"] = None

--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -392,11 +392,13 @@ def get_run_data(request):
             run_data["current_section"] = run.current_step.section
             run_data["current_step_index"] = run.steps.current_step_index
             run_data["memory_usage"] = get_memory_usage()
+            run_data["current_step_has_plot"] = bool(run.current_step.plot_method)
         else:
             run_data["displayed_steps"] = []
             run_data["current_section"] = None
             run_data["current_step"] = None
             run_data["memory_usage"] = get_memory_usage()
+            run_data["current_step_has_plot"] = False
 
         return JsonResponse({"success": True, "message": "Got the data for the run", "data": run_data}, safe=False)
     else:

--- a/frontend/src/components/app/run-screen/run-screen.tsx
+++ b/frontend/src/components/app/run-screen/run-screen.tsx
@@ -168,6 +168,13 @@ export const RunScreen: React.FC = () => {
     openDownloadModal();
   };
 
+  let plotPlaceholderMessage;
+  if (runData.current_step_has_plot) {
+    plotPlaceholderMessage = "Run calculation to generate plot.";
+  } else {
+    plotPlaceholderMessage = "No plot available for this step.";
+  }
+
   const plotComponent = (
     <StyledContentContainer>
       {plots && plots.length > 0 ? (
@@ -192,7 +199,7 @@ export const RunScreen: React.FC = () => {
           />
         </>
       ) : (
-        <SectionTitle baseComponent={"h4"} description={"No plot available for this step."} />
+        <SectionTitle baseComponent={"h4"} description={plotPlaceholderMessage} />
       )}
     </StyledContentContainer>
   );

--- a/frontend/src/utils/protzilla-types.ts
+++ b/frontend/src/utils/protzilla-types.ts
@@ -69,6 +69,7 @@ export interface RunData {
   current_step_index: number;
   displayed_steps: Section[];
   memory_usage: string;
+  current_step_has_plot: boolean;
 }
 
 export const emptyRunData: RunData = {
@@ -76,6 +77,7 @@ export const emptyRunData: RunData = {
   current_step_index: 0,
   displayed_steps: emptySections,
   memory_usage: "",
+  current_step_has_plot: false,
 };
 
 export interface Table {


### PR DESCRIPTION
## Description
fixes #93 
Adjust plot placeholder text so that steps which can generate a plot no longer show a misleading “No plot available for this step.” message before the calculation is run.

## Changes
- **backend/main/views.py**
  - Add `current_step_has_plot` flag to `run_data` based on `run.current_step.plot_method`.
- **frontend/src/utils/protzilla-types.ts**
  - Extend `RunData` with `current_step_has_plot: boolean` and set it in `emptyRunData`.
- **frontend/src/components/app/run-screen/run-screen.tsx**
  - Use `runData.current_step_has_plot` to choose between:
    - `"Run calculation to generate plot."` (step can have a plot)
    - `"No plot available for this step."` (step never has a plot)

## Testing
- Open a step that can produce a plot but hasn’t been run yet → shows “Run calculation to generate plot.”
- Run the calculation on that step → plot appears as before.
- Open a step that never has a plot → still shows “No plot available for this step.”
- Navigate between steps with and without plots to ensure no errors and unchanged behavior apart from the placeholder text.
