### PR TITLE
100 bug workflow import doesnt validate zip archive

### DIFF
--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -328,7 +328,7 @@ def import_workflow(request):
         workflow_file = settings.FILE_UPLOAD_TEMP_DIR / workflow
 
         if new_name == "":
-            copy2(str(workflow_file), str(WORKFLOWS_PATH / workflow))
+            copy2(str(workflow_file), str((WORKFLOWS_PATH / workflow).with_suffix(".yaml")))
         else:
             try:
                 copy2(str(workflow_file), str(WORKFLOWS_PATH / f"{new_name}.yaml"))

--- a/backend/protzilla/workflow.py
+++ b/backend/protzilla/workflow.py
@@ -7,7 +7,7 @@ def get_available_workflow_names() -> list[str]:
     return [
         file.stem
         for file in paths.WORKFLOWS_PATH.iterdir()
-        if not file.name.startswith(".") and not file.suffix == ".json"
+        if not file.name.startswith(".") and file.suffix == ".yaml"
     ]
 
 def delete_workflow_file(name: str) -> tuple[bool, str]:

--- a/frontend/src/components/app/index-screen/index-screen.tsx
+++ b/frontend/src/components/app/index-screen/index-screen.tsx
@@ -576,6 +576,7 @@ export const IndexScreen: React.FC = () => {
                     name: "workflow",
                     label: "Workflow:",
                     isVisible: true,
+                    accept: ".yaml, .yml"
                   },
                   {
                     type: "text",

--- a/frontend/src/components/core/shared/input-fields/file-input-field/file-input-field.props.ts
+++ b/frontend/src/components/core/shared/input-fields/file-input-field/file-input-field.props.ts
@@ -5,5 +5,6 @@ import { InputContainerProps } from "../input-container";
 export interface FileInputFieldProps extends InputContainerProps, UIStateProps {
   value?: string | null; // The filename
   placeholder?: string;
+  accept?: string;
   onChange: (value: string) => void;
 }

--- a/frontend/src/components/core/shared/input-fields/file-input-field/file-input-field.tsx
+++ b/frontend/src/components/core/shared/input-fields/file-input-field/file-input-field.tsx
@@ -28,6 +28,7 @@ const StyledSpan = styled.span`
 export const FileInputField: React.FC<FileInputFieldProps> = ({
   value = null,
   placeholder = "No file chosen",
+  accept = "*/*",
   onChange,
   ...props
 }) => {
@@ -92,7 +93,7 @@ export const FileInputField: React.FC<FileInputFieldProps> = ({
     }
   };
 
-  const openFilePicker = useFilePicker(handleFileSelection, "*/*", false);
+  const openFilePicker = useFilePicker(handleFileSelection, accept, false);
 
   return (
     <InputContainer {...props}>


### PR DESCRIPTION
## Description

fixes #100 

Before this fix, any kind of file (with any extension) could be uploaded as a workflow. But when deleting from the frontend, the code expected the file to be found at `WORKFLOWS_PATH/<name>.yaml`, so it couldn't ever be deleted.

## Changes

Now, the file picker only shows `.yaml` or `.yml` as accepted filetypes and the backend saves all files with the `.yaml` extension.


## Testing

1. Upload a workflow template
2. File is saved as .yaml in the correct folder
3. Run can be created from the + button
4. Workflow template can be deleted

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
