### PR TITLE
92 bug import step loses state on revisit and blocks re import

### DIFF
--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -94,6 +94,10 @@ class MaxQuantImport(ImportingStep):
             ],
         )
 
+    def modify_form(self, form, run):
+        if run.steps.current_step.calculation_status == "complete":
+            form.input_fields[0].value = None
+
     calc_method = staticmethod(max_quant_import)
 
 

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -65,7 +65,7 @@ class ImportingStep(Step):
     def index_of_file_input(self):
         """
         Returns the index of the FileInput that should be reset by modify_form. This method 
-        must be overriden if the FileInput is not index 0.    
+        must be overridden if the FileInput is not index 0.    
         """
         return 0
 

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -57,6 +57,18 @@ class ImportingStep(Step):
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
         return inputs
 
+    def modify_form(self, form, run):
+        Step.modify_form(self, form, run)
+        if run.steps.current_step.calculation_status == "complete":
+            form.input_fields[self.index_of_file_input()].value = None
+
+    def index_of_file_input(self):
+        """
+        Returns the index of the FileInput that should be reset by modify_form. This method 
+        must be overriden if the FileInput is not index 0.    
+        """
+        return 0
+
 
 class MaxQuantImport(ImportingStep):
     display_name = "MaxQuant Protein Groups Import"
@@ -93,10 +105,6 @@ class MaxQuantImport(ImportingStep):
                 ),
             ],
         )
-
-    def modify_form(self, form, run):
-        if run.steps.current_step.calculation_status == "complete":
-            form.input_fields[0].value = None
 
     calc_method = staticmethod(max_quant_import)
 
@@ -326,6 +334,8 @@ class PeptideImport(ImportingStep):
         )
     
     def modify_form(self, form, run):
+        ImportingStep.modify_form(self, form, run)
+
         intensity_name_field = form["intensity_name"]
         map_to_uniprot_field = form["map_to_uniprot"]
 
@@ -368,6 +378,8 @@ class EvidenceImport(ImportingStep):
         )
     
     def modify_form(self, form, run):
+        ImportingStep.modify_form(self, form, run)
+
         map_to_uniprot_field = form["map_to_uniprot"]
 
         map_to_uniprot_field.value = run.steps.get_step_input(


### PR DESCRIPTION
## Description
fixes #92 
For the importing steps, when reverting back to a step the file input field shows "No file chosen" now instead of showing the name of the previously chosen file, which is no longer available and would cause an error when imported again.  

## Changes
In backend/protzilla/methods/importing.py the ImportingStep class was extended by the modify_form method (which is supposed to be overridden and called when clicking on a step). This method now changes the value of the input field of any ImportingStep based on its status so that the placeholder is shown instead of the previously selected file. 
For every ImportingStep that already had its own implementation of the modify_form method, a call to the super method was added (except for the ones that did not have an input field). 


## Testing
Upload a file in any importing step and click on "Import" and "Next" after the successful input. Now revert back to this step and see that the input field shows no file chosen, indicating correctly that a new file needs to be chosen before a new "Import". 

## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [ ] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
