### PR TITLE
Fix linked scrolling between step list and parameter view

### DIFF
--- a/frontend/src/components/app/main-screen.tsx
+++ b/frontend/src/components/app/main-screen.tsx
@@ -13,8 +13,9 @@ const MainContent = styled(SubScreen)`
   flex: 1;
   gap: ${spacing("large")};
   min-width: 0;
-  overflow-y: auto;
-  overflow-x: hidden;
+  height: 100vh;
+  min-height: 0;
+  overflow: hidden;
   width: 100%;
 `;
 

--- a/frontend/src/components/app/run-screen/list-editor/list-editor.tsx
+++ b/frontend/src/components/app/run-screen/list-editor/list-editor.tsx
@@ -24,12 +24,30 @@ const StyledDivider = styled.div`
 const StyledFormColumn = styled.div`
   display: flex;
   flex-direction: column;
-  gap: ${spacing("large")};
   width: 20vw;
   min-width: 250px;
   max-width: 500px;
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: auto;
+  min-height: 0;
+  gap: ${spacing("large")};
   padding-top: ${spacing("small")};
+  padding-bottom: ${spacing("medium")};
+  padding-right: ${spacing("medium")};
   margin: 0 ${spacing("small")};
+`;
+
+const StyledSidebarContainer = styled.div`
+  min-width: 0px;
+  max-width: 500px;
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  padding-right: ${spacing("medium")};
 `;
 
 export const ListEditor: React.FC<ListEditorProps> = ({
@@ -104,13 +122,15 @@ export const ListEditor: React.FC<ListEditorProps> = ({
 
   return (
     <StyledRow>
-      <Sidebar
-        runName={runName}
-        runData={runData}
-        sections={sections}
-        stepSectionIndex={stepSectionIndex}
-        navigateOrRefreshSteps={navigateOrRefreshSteps}
-      />
+      <StyledSidebarContainer>
+        <Sidebar
+          runName={runName}
+          runData={runData}
+          sections={sections}
+          stepSectionIndex={stepSectionIndex}
+          navigateOrRefreshSteps={navigateOrRefreshSteps}
+        />
+      </StyledSidebarContainer>
 
       <StyledDivider />
 

--- a/frontend/src/components/app/run-screen/run-screen.tsx
+++ b/frontend/src/components/app/run-screen/run-screen.tsx
@@ -35,6 +35,7 @@ const StyledCardRow = styled(FlexRow)`
   gap: ${spacing("small")};
   flex: 1;
   height: 100%;
+  min-height: 0;
 `;
 
 const StyledFlexColumn = styled(FlexColumn)`
@@ -234,7 +235,7 @@ export const RunScreen: React.FC = () => {
   );
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+    <div style={{ display: "flex", flexDirection: "column", height: "100vh", overflow: "hidden" }}>
       <StyledNavbar
         showRunInformation={true}
         title={runName}

--- a/frontend/src/components/core/shared/cards/card/card.tsx
+++ b/frontend/src/components/core/shared/cards/card/card.tsx
@@ -13,13 +13,12 @@ const StyledCard = styledDiv.div`
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow-y: auto;
 `;
 
 const CardBody = styledDiv.div<{ hasTitle: boolean }>`
   padding: ${spacing("small")};
   flex: 1;
-  
+  overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: #ccc transparent;
 `;


### PR DESCRIPTION
## Description
fixes #94

Make the step list (left sidebar) and the parameter view (middle column) scroll independently so that long step lists are easier to navigate while keeping parameters in view.

## Changes
- The main parent container no longer scrolls; instead, the step list and the parameter view now have their own independent scroll areas.
- Adjusted the layout to better use the viewport height (e.g. `100vh`) and improved general window size handling to avoid nested or duplicate scrollbars.

## Testing
1. Open the run screen with a workflow that has many steps.
2. Verify that:
   - The **step list** (left sidebar) has its own scrollbar and can be scrolled independently.
   - The **parameter view** (middle column) has its own scrollbar and can be scrolled independently of the step list.
3. Confirm that the main page (outside of these areas) no longer scrolls, and that layout behaves correctly when resizing the browser window.
4. Open a card with enough content to require scrolling and verify that the scrollbar appears inside the card body and no extra outer scrollbars are introduced.

**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`

**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes