### PR TITLE
feat: add filtering based on SILAC ratios

### DIFF
--- a/backend/protzilla/all_steps.py
+++ b/backend/protzilla/all_steps.py
@@ -14,6 +14,7 @@ _forward_mapping = [
     importing.EvidenceImport,
     importing.ExampleDatasetImport,
     data_preprocessing.FilterProteinsBySamplesMissing,
+    data_preprocessing.FilterProteinsBySilacRatios,
     data_preprocessing.FilterByProteinsCount,
     data_preprocessing.FilterSamplesByProteinsMissing,
     data_preprocessing.FilterSamplesByProteinIntensitiesSum,

--- a/backend/protzilla/data_preprocessing/filter_proteins.py
+++ b/backend/protzilla/data_preprocessing/filter_proteins.py
@@ -62,7 +62,7 @@ def by_silac_ratios(
     """
 
     intensity_name = default_intensity_column(protein_df)
-    unique_ratio_count = protein_df.groupby("Protein ID")[intensity_name].unique()
+    unique_ratio_count = protein_df.groupby("Protein ID")[intensity_name].nunique()
     remaining_proteins_list = unique_ratio_count[
         unique_ratio_count >= min_amount
     ].index.tolist()

--- a/backend/protzilla/data_preprocessing/filter_proteins.py
+++ b/backend/protzilla/data_preprocessing/filter_proteins.py
@@ -2,6 +2,8 @@ import pandas as pd
 
 from backend.protzilla.data_preprocessing.plots import create_bar_plot, create_pie_plot
 
+from backend.protzilla.utilities.utilities import default_intensity_column
+
 from ..utilities.transform_dfs import long_to_wide
 
 
@@ -44,7 +46,56 @@ def by_samples_missing(
     )
 
 
+def by_silac_ratios(
+    protein_df: pd.DataFrame,
+    peptide_df: pd.DataFrame | None,
+    min_amount: int,
+) -> dict:
+    """
+    This function filters proteins based on the amount of samples with different SILAC ratios.
+
+    :param protein_df: the protein dataframe that should be filtered
+    :param peptide_df: the peptide dataframe that should be filtered in accordance to the intensity dataframe (optional)
+    :param min_amount: defines the minimum amount of samples the protein has to have an intensity in (inclusive)
+    :return: returns the filtered df as a Dataframe and a dict with a list of Protein IDs that were discarded
+        and a list of Protein IDs that were kept
+    """
+
+    intensity_name = default_intensity_column(protein_df)
+    ratio_count = protein_df.groupby("Protein ID")[intensity_name].count()
+    remaining_proteins_list = ratio_count[ratio_count >= min_amount].index.tolist()
+    filtered_proteins_list = ratio_count.drop(remaining_proteins_list).index.tolist()
+    filtered_df = protein_df[(protein_df["Protein ID"].isin(remaining_proteins_list))]
+    filtered_peptide_df = None
+    if peptide_df is not None:
+        filtered_peptide_df = peptide_df[
+            (peptide_df["Protein ID"].isin(remaining_proteins_list))
+        ]
+    return dict(
+        protein_df=filtered_df,
+        peptide_df=filtered_peptide_df,
+        filtered_proteins=filtered_proteins_list,
+        remaining_proteins=remaining_proteins_list,
+    )
+
+
 def by_samples_missing_plot(
+    output_remaining_proteins, output_filtered_proteins, graph_type
+):
+    return _build_pie_bar_plot(
+        output_remaining_proteins, output_filtered_proteins, graph_type
+    )
+
+
+def by_silac_ratios_plot(
+    output_remaining_proteins, output_filtered_proteins, graph_type
+):
+    return _build_pie_bar_plot(
+        output_remaining_proteins, output_filtered_proteins, graph_type
+    )
+
+
+def _build_pie_bar_plot(
     output_remaining_proteins, output_filtered_proteins, graph_type
 ):
     if graph_type == "Pie chart":

--- a/backend/protzilla/data_preprocessing/filter_proteins.py
+++ b/backend/protzilla/data_preprocessing/filter_proteins.py
@@ -52,19 +52,19 @@ def by_silac_ratios(
     min_amount: int,
 ) -> dict:
     """
-    This function filters proteins based on the amount of samples with different SILAC ratios.
+    This function filters proteins based on the amount of samples with unique SILAC ratios.
 
     :param protein_df: the protein dataframe that should be filtered
     :param peptide_df: the peptide dataframe that should be filtered in accordance to the intensity dataframe (optional)
-    :param min_amount: defines the minimum amount of samples the protein has to have an intensity in (inclusive)
+    :param min_amount: defines the minimum amount of samples the protein has to have a unique intensity in (inclusive)
     :return: returns the filtered df as a Dataframe and a dict with a list of Protein IDs that were discarded
         and a list of Protein IDs that were kept
     """
 
     intensity_name = default_intensity_column(protein_df)
-    ratio_count = protein_df.groupby("Protein ID")[intensity_name].count()
-    remaining_proteins_list = ratio_count[ratio_count >= min_amount].index.tolist()
-    filtered_proteins_list = ratio_count.drop(remaining_proteins_list).index.tolist()
+    unique_ratio_count = protein_df.groupby("Protein ID")[intensity_name].unique()
+    remaining_proteins_list = unique_ratio_count[unique_ratio_count >= min_amount].index.tolist()
+    filtered_proteins_list = unique_ratio_count.drop(remaining_proteins_list).index.tolist()
     filtered_df = protein_df[(protein_df["Protein ID"].isin(remaining_proteins_list))]
     filtered_peptide_df = None
     if peptide_df is not None:

--- a/backend/protzilla/data_preprocessing/filter_proteins.py
+++ b/backend/protzilla/data_preprocessing/filter_proteins.py
@@ -63,8 +63,12 @@ def by_silac_ratios(
 
     intensity_name = default_intensity_column(protein_df)
     unique_ratio_count = protein_df.groupby("Protein ID")[intensity_name].unique()
-    remaining_proteins_list = unique_ratio_count[unique_ratio_count >= min_amount].index.tolist()
-    filtered_proteins_list = unique_ratio_count.drop(remaining_proteins_list).index.tolist()
+    remaining_proteins_list = unique_ratio_count[
+        unique_ratio_count >= min_amount
+    ].index.tolist()
+    filtered_proteins_list = unique_ratio_count.drop(
+        remaining_proteins_list
+    ).index.tolist()
     filtered_df = protein_df[(protein_df["Protein ID"].isin(remaining_proteins_list))]
     filtered_peptide_df = None
     if peptide_df is not None:

--- a/backend/protzilla/methods/data_preprocessing.py
+++ b/backend/protzilla/methods/data_preprocessing.py
@@ -134,8 +134,8 @@ class FilterProteinsBySilacRatios(DataPreprocessingStep):
             ],
         )
 
-    calc_method = staticmethod(filter_proteins.by_samples_missing)
-    plot_method = staticmethod(filter_proteins.by_samples_missing_plot)
+    calc_method = staticmethod(filter_proteins.by_silac_ratios)
+    plot_method = staticmethod(filter_proteins.by_silac_ratios_plot)
 
 
 class FilterByProteinsCount(DataPreprocessingStep):

--- a/backend/protzilla/methods/data_preprocessing.py
+++ b/backend/protzilla/methods/data_preprocessing.py
@@ -105,6 +105,39 @@ class FilterProteinsBySamplesMissing(DataPreprocessingStep):
     plot_method = staticmethod(filter_proteins.by_samples_missing_plot)
 
 
+class FilterProteinsBySilacRatios(DataPreprocessingStep):
+    display_name = "By SILAC ratios"
+    operation = "filter_proteins"
+    method_description = (
+        "Filter proteins based on the amount of samples with SILAC ratios"
+    )
+
+    input_keys = ["protein_df", "peptide_df", "min_amount"]
+
+    def create_form(self):
+        return Form(
+            label="Filter Proteins by SILAC ratios",
+            input_fields=[
+                FloatField(
+                    name="min_amount",
+                    label="Amount of minimum present samples with SILAC ratios",
+                    value=1,
+                    min=0,
+                    step=1,
+                ),
+                DropdownField(
+                    name="graph_type",
+                    label="Graph type",
+                    value=BarAndPieChart.pie_chart.value,
+                    options=BarAndPieChart,
+                ),
+            ],
+        )
+
+    calc_method = staticmethod(filter_proteins.by_samples_missing)
+    plot_method = staticmethod(filter_proteins.by_samples_missing_plot)
+
+
 class FilterByProteinsCount(DataPreprocessingStep):
     display_name = "Protein Count"
     operation = "filter_samples"

--- a/backend/protzilla/methods/data_preprocessing.py
+++ b/backend/protzilla/methods/data_preprocessing.py
@@ -109,7 +109,7 @@ class FilterProteinsBySilacRatios(DataPreprocessingStep):
     display_name = "By SILAC ratios"
     operation = "filter_proteins"
     method_description = (
-        "Filter proteins based on the amount of samples with SILAC ratios"
+        "Filter proteins based on the amount of samples with SILAC different ratios"
     )
 
     input_keys = ["protein_df", "peptide_df", "min_amount"]
@@ -120,7 +120,7 @@ class FilterProteinsBySilacRatios(DataPreprocessingStep):
             input_fields=[
                 NumberField(
                     name="min_amount",
-                    label="Amount of minimum present samples with SILAC ratios",
+                    label="Amount of minimum present samples with different SILAC ratios",
                     value=1,
                     min=0,
                     step=1,

--- a/backend/protzilla/methods/data_preprocessing.py
+++ b/backend/protzilla/methods/data_preprocessing.py
@@ -118,7 +118,7 @@ class FilterProteinsBySilacRatios(DataPreprocessingStep):
         return Form(
             label="Filter Proteins by SILAC ratios",
             input_fields=[
-                FloatField(
+                NumberField(
                     name="min_amount",
                     label="Amount of minimum present samples with SILAC ratios",
                     value=1,

--- a/backend/tests/main/test_views_helper.py
+++ b/backend/tests/main/test_views_helper.py
@@ -13,6 +13,7 @@ def test_get_all_possible_step_names():
         "EvidenceImport",
         "ExampleDatasetImport",
         "FilterProteinsBySamplesMissing",
+        "FilterProteinsBySilacRatios",
         "FilterByProteinsCount",
         "FilterSamplesByProteinsMissing",
         "FilterSamplesByProteinIntensitiesSum",

--- a/backend/tests/protzilla/data_preprocessing/test_filter_proteins.py
+++ b/backend/tests/protzilla/data_preprocessing/test_filter_proteins.py
@@ -75,6 +75,37 @@ def filter_proteins_by_samples_missing_df():
     return df
 
 
+@pytest.fixture
+def filter_proteins_by_silac_ratios_df():
+    filter_proteins_df = pd.DataFrame(
+        (
+            ["Sample2", "Protein2", "Gene2", 0.5],
+            ["Sample4", "Protein4", "Gene4", 0.7],
+            ["Sample1", "Protein1", "Gene1", np.nan],
+            ["Sample3", "Protein3", "Gene3", 0.8],
+            ["Sample1", "Protein2", "Gene2", 0.5],
+            ["Sample1", "Protein3", "Gene3", 1.2],
+            ["Sample2", "Protein1", "Gene1", np.nan],
+            ["Sample2", "Protein3", "Gene3", 0.35],
+            ["Sample3", "Protein1", "Gene1", np.nan],
+            ["Sample3", "Protein2", "Gene2", np.nan],
+            ["Sample4", "Protein2", "Gene2", np.nan],
+            ["Sample4", "Protein3", "Gene3", 0.85],
+            ["Sample1", "Protein4", "Gene4", np.nan],
+            ["Sample2", "Protein4", "Gene4", 0.51],
+            ["Sample3", "Protein4", "Gene4", np.nan],
+            ["Sample4", "Protein1", "Gene1", 0.25],
+        ),
+        columns=["Sample", "Protein ID", "Gene", "Ratio H/L"],
+    )
+
+    filter_proteins_df.sort_values(
+        by=["Sample", "Protein ID"], ignore_index=True, inplace=True
+    )
+
+    return filter_proteins_df
+
+
 def test_filter_proteins_by_missing_samples(
     filter_proteins_by_samples_missing_df, peptides_df, show_figures
 ):
@@ -125,9 +156,11 @@ def test_filter_proteins_by_missing_samples(
     )
 
 
-def test_filter_proteins_by_silac_ratios(filter_proteins_df, peptides_df, show_figures):
+def test_filter_proteins_by_silac_ratios(
+    filter_proteins_by_silac_ratios_df, peptides_df, show_figures
+):
 
-    method_output = by_silac_ratios(filter_proteins_df, peptide_df=None, min_amount=2)
+    method_output = by_silac_ratios(filter_proteins_by_silac_ratios_df, peptide_df=None, min_amount=2)
 
     fig = by_silac_ratios_plot(
         method_output["remaining_proteins"],
@@ -137,16 +170,16 @@ def test_filter_proteins_by_silac_ratios(filter_proteins_df, peptides_df, show_f
     if show_figures:
         fig.show()
 
-    assert method_output["remaining_proteins"] == ["Protein2", "Protein3", "Protein4"]
-    assert method_output["filtered_proteins"] == ["Protein1"]
+    assert method_output["remaining_proteins"] == ["Protein3", "Protein4"]
+    assert method_output["filtered_proteins"] == ["Protein1", "Protein2"]
 
-    method_output = by_silac_ratios(filter_proteins_df, peptide_df=None, min_amount=4)
+    method_output = by_silac_ratios(filter_proteins_by_silac_ratios_df, peptide_df=None, min_amount=4)
 
     assert method_output["remaining_proteins"] == ["Protein3"]
     assert method_output["filtered_proteins"] == ["Protein1", "Protein2", "Protein4"]
 
     method_output = by_silac_ratios(
-        filter_proteins_df, peptide_df=peptides_df, min_amount=4
+        filter_proteins_by_silac_ratios_df, peptide_df=peptides_df, min_amount=4
     )
 
     assert_peptide_filtering_matches_protein_filtering(

--- a/backend/tests/protzilla/data_preprocessing/test_filter_proteins.py
+++ b/backend/tests/protzilla/data_preprocessing/test_filter_proteins.py
@@ -5,6 +5,7 @@ import pytest
 from backend.protzilla.data_preprocessing.filter_proteins import (
     by_samples_missing,
     by_samples_missing_plot,
+    by_silac_ratios,
 )
 from backend.tests.protzilla.data_preprocessing.test_peptide_preprocessing import (
     assert_peptide_filtering_matches_protein_filtering,
@@ -114,6 +115,38 @@ def test_filter_proteins_by_missing_samples(
     method_output["filtered_proteins"]
 
     assert method_output["filtered_proteins"] == []
+
+    assert_peptide_filtering_matches_protein_filtering(
+        method_output["protein_df"],
+        peptides_df,
+        method_output["peptide_df"],
+        "Protein ID",
+    )
+
+
+def test_filter_proteins_by_silac_ratios(filter_proteins_df, peptides_df, show_figures):
+
+    method_output = by_silac_ratios(filter_proteins_df, peptide_df=None, min_amount=2)
+
+    fig = by_samples_missing_plot(
+        method_output["remaining_proteins"],
+        method_output["filtered_proteins"],
+        "Pie chart",
+    )[0]
+    if show_figures:
+        fig.show()
+
+    assert method_output["remaining_proteins"] == ["Protein2", "Protein3", "Protein4"]
+    assert method_output["filtered_proteins"] == ["Protein1"]
+
+    method_output = by_silac_ratios(filter_proteins_df, peptide_df=None, min_amount=4)
+
+    assert method_output["remaining_proteins"] == ["Protein3"]
+    assert method_output["filtered_proteins"] == ["Protein1", "Protein2", "Protein4"]
+
+    method_output = by_silac_ratios(
+        filter_proteins_df, peptide_df=peptides_df, min_amount=4
+    )
 
     assert_peptide_filtering_matches_protein_filtering(
         method_output["protein_df"],

--- a/backend/tests/protzilla/data_preprocessing/test_filter_proteins.py
+++ b/backend/tests/protzilla/data_preprocessing/test_filter_proteins.py
@@ -6,6 +6,7 @@ from backend.protzilla.data_preprocessing.filter_proteins import (
     by_samples_missing,
     by_samples_missing_plot,
     by_silac_ratios,
+    by_silac_ratios_plot,
 )
 from backend.tests.protzilla.data_preprocessing.test_peptide_preprocessing import (
     assert_peptide_filtering_matches_protein_filtering,
@@ -128,7 +129,7 @@ def test_filter_proteins_by_silac_ratios(filter_proteins_df, peptides_df, show_f
 
     method_output = by_silac_ratios(filter_proteins_df, peptide_df=None, min_amount=2)
 
-    fig = by_samples_missing_plot(
+    fig = by_silac_ratios_plot(
         method_output["remaining_proteins"],
         method_output["filtered_proteins"],
         "Pie chart",

--- a/backend/tests/protzilla/data_preprocessing/test_filter_proteins.py
+++ b/backend/tests/protzilla/data_preprocessing/test_filter_proteins.py
@@ -160,7 +160,9 @@ def test_filter_proteins_by_silac_ratios(
     filter_proteins_by_silac_ratios_df, peptides_df, show_figures
 ):
 
-    method_output = by_silac_ratios(filter_proteins_by_silac_ratios_df, peptide_df=None, min_amount=2)
+    method_output = by_silac_ratios(
+        filter_proteins_by_silac_ratios_df, peptide_df=None, min_amount=2
+    )
 
     fig = by_silac_ratios_plot(
         method_output["remaining_proteins"],
@@ -173,7 +175,9 @@ def test_filter_proteins_by_silac_ratios(
     assert method_output["remaining_proteins"] == ["Protein3", "Protein4"]
     assert method_output["filtered_proteins"] == ["Protein1", "Protein2"]
 
-    method_output = by_silac_ratios(filter_proteins_by_silac_ratios_df, peptide_df=None, min_amount=4)
+    method_output = by_silac_ratios(
+        filter_proteins_by_silac_ratios_df, peptide_df=None, min_amount=4
+    )
 
     assert method_output["remaining_proteins"] == ["Protein3"]
     assert method_output["filtered_proteins"] == ["Protein1", "Protein2", "Protein4"]


### PR DESCRIPTION
## Description
fixes #134

adds the preprocessing step for filtering based on the amount of samples that a given protein has intensity records in.

## Changes

- rebased from #137  branch
- `backend/protzilla/data_preprocessing/filter_proteins.py`: add `by_silac_ratios` method
- `backend/protzilla/methods/data_preprocessing.py`: add `FilterProteinsBySilacRatios` step for the frontend
- `backend/tests/protzilla/data_preprocessing/test_filter_proteins.py`: add basic testing for the filtering


## Testing

- for whatever reason, when testing `by_silac_ratios` in the backend, everything works as expected. Using the [paper's dataset](https://ftp.pride.ebi.ac.uk/pride/data/archive/2020/04/PXD014997/SEARCH-IDENTIFICATIONS_REL_FREE-RELAPSE.7z) in an example workflow from the web UI always results in the same amount of proteins getting filtered, regardless of the amount enterd (the corresponding input would be 105). I could not reproduce this behaviour when debugging in pytest. Maybe it's just an odd error on my machine?

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint` (nothing in the frontend was touched)
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
