### PR TITLE
FIX: 157 silac import pulls wrong columns

### DIFF
--- a/backend/protzilla/importing/ms_data_import.py
+++ b/backend/protzilla/importing/ms_data_import.py
@@ -36,7 +36,9 @@ def max_quant_import(
         ):
             base_pattern = rf"^{re.escape(intensity_name)}\s(?!normalized\b)(?!.*\b{disallowed_suffixes}\b).*$"
         else:
-            base_pattern = rf"^{re.escape(intensity_name)}\s(?!.*\b{disallowed_suffixes}\b).*$"
+            base_pattern = (
+                rf"^{re.escape(intensity_name)}\s(?!.*\b{disallowed_suffixes}\b).*$"
+            )
 
         intensity_df = df.filter(regex=base_pattern, axis=1)
 

--- a/backend/protzilla/importing/ms_data_import.py
+++ b/backend/protzilla/importing/ms_data_import.py
@@ -29,9 +29,16 @@ def max_quant_import(
             keep_default_na=True,
         )
         protein_groups = df["Majority protein IDs"]
-        # filter out normalized so "Ratio H/L normalized" is not filtered for "Ratio H/L" - same for L/H
-        intensity_df = df.filter(regex=f"^{intensity_name} (?!normalized)", axis=1)
-        intensity_df = intensity_df.filter(regex=r"^(?!.*peptides).*$", axis=1)
+        disallowed_suffixes = r"(variability|count|type|peptides)"
+        if intensity_name in (
+            IntensityType.RATIO_HL.value,
+            IntensityType.RATIO_LH.value,
+        ):
+            base_pattern = rf"^{re.escape(intensity_name)}\s(?!normalized\b)(?!.*\b{disallowed_suffixes}\b).*$"
+        else:
+            base_pattern = rf"^{re.escape(intensity_name)}\s(?!.*\b{disallowed_suffixes}\b).*$"
+
+        intensity_df = df.filter(regex=base_pattern, axis=1)
 
         if intensity_df.empty:
             msg = f"{intensity_name} was not found in the provided file, please use another intensity and try again or verify your file."

--- a/backend/protzilla/importing/peptide_import.py
+++ b/backend/protzilla/importing/peptide_import.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+import re
 
 import pandas as pd
 
@@ -36,8 +37,18 @@ def peptide_import(file_path: Path, intensity_name: str, map_to_uniprot) -> dict
 
     if "Sample" not in df.columns:
         id_df = df[id_columns]
-        # filter out normalized so "Ratio H/L normalized" is not filtered for "Ratio H/L" - same for L/H
-        intensity_df = df.filter(regex=f"^{intensity_name} (?!normalized)", axis=1)
+        disallowed_suffixes = r"(variability|count|type|peptides)"
+        if intensity_name in (
+            IntensityType.RATIO_HL.value,
+            IntensityType.RATIO_LH.value,
+        ):
+            base_pattern = rf"^{re.escape(intensity_name)}\s(?!normalized\b)(?!.*\b{disallowed_suffixes}\b).*$"
+        else:
+            base_pattern = (
+                rf"^{re.escape(intensity_name)}\s(?!.*\b{disallowed_suffixes}\b).*$"
+            )
+
+        intensity_df = df.filter(regex=base_pattern, axis=1)
         intensity_df.columns = [
             c[len(intensity_name) + 1 :] for c in intensity_df.columns
         ]


### PR DESCRIPTION
## Description
fixes #157  
Tighten MaxQuant ratio import so only the selected ratio columns are ingested and auxiliary columns (normalized, variability, count, type, peptides) are ignored for the non-normalized selection.

## Changes
- Update `backend/protzilla/importing/ms_data_import.py` to build a stricter regex for ratio imports, excluding normalized/auxiliary columns unless explicitly chosen.
- This Branch is based on #141; So please ignore all other changes except `backend/protzilla/importing/ms_data_import.py`

## Testing
- `python3 -m pytest backend/tests/protzilla/importing/test_ms_data_import.py::test_max_quant_import_different_intensity_names`
- Looking at the data

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [x] At least one other developer reviewed and approved the changes
