### PR TITLE
131: Adjust preprocessing steps to work with ratios

### DIFF
--- a/backend/protzilla/constants/option_types.py
+++ b/backend/protzilla/constants/option_types.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 class EmptyEnum(Enum):
     pass
 

--- a/backend/protzilla/constants/option_types.py
+++ b/backend/protzilla/constants/option_types.py
@@ -1,0 +1,41 @@
+from enum import Enum
+
+class EmptyEnum(Enum):
+    pass
+
+
+class LogTransformationBaseType(Enum):
+    LOG2 = "log2"
+    LOG10 = "log10"
+
+
+class SimpleImputerStrategyType(Enum):
+    MEAN = "mean"
+    MEDIAN = "median"
+    MOST_FREQUENT = "most_frequent"
+
+
+class ImputationByNormalDistributionSamplingStrategyType(Enum):
+    PER_PROTEIN = "perProtein"
+    PER_DATASET = "perDataset"
+
+
+class BarAndPieChart(Enum):
+    BAR_PLOT = "Bar chart"
+    PIE_CHART = "Pie chart"
+
+
+class BoxAndHistogramGraph(Enum):
+    BOXPLOT = "Boxplot"
+    HISTOGRAM = "Histogram"
+
+
+class GroupBy(Enum):
+    NO_GROUPING = "None"
+    SAMPLE = "Sample"
+    PROTEIN_ID = "Protein ID"
+
+
+class VisualTransformations(Enum):
+    LOG10 = "log10"
+    LINEAR = "linear"

--- a/backend/protzilla/data_preprocessing/imputation.py
+++ b/backend/protzilla/data_preprocessing/imputation.py
@@ -13,7 +13,7 @@ from backend.protzilla.data_preprocessing.plots import (
 )
 from backend.protzilla.utilities import default_intensity_column
 from backend.protzilla.utilities.transform_dfs import long_to_wide, wide_to_long
-from backend.protzilla.constants.option_types import SimpleImputerStrategyType
+from backend.protzilla.constants.option_types import SimpleImputerStrategyType, ImputationByNormalDistributionSamplingStrategyType
 
 
 def flag_invalid_values(df: pd.DataFrame, messages: list) -> dict:
@@ -281,7 +281,7 @@ def by_normal_distribution_sampling(
     a list of messages
     """
     assert strategy in {
-        item.value for value in ImputationByNormalDistributionSamplingStrategyType
+        item.value for item in ImputationByNormalDistributionSamplingStrategyType
     }
 
     if strategy == ImputationByNormalDistributionSamplingStrategyType.PER_PROTEIN.value:

--- a/backend/protzilla/data_preprocessing/imputation.py
+++ b/backend/protzilla/data_preprocessing/imputation.py
@@ -280,7 +280,9 @@ def by_normal_distribution_sampling(
     :return: returns an imputed dataframe in typical protzilla long format\
     a list of messages
     """
-    assert strategy in {item.value for value in ImputationByNormalDistributionSamplingStrategyType}
+    assert strategy in {
+        item.value for value in ImputationByNormalDistributionSamplingStrategyType
+    }
 
     if strategy == ImputationByNormalDistributionSamplingStrategyType.PER_PROTEIN.value:
         transformed_df = long_to_wide(protein_df)

--- a/backend/protzilla/data_preprocessing/imputation.py
+++ b/backend/protzilla/data_preprocessing/imputation.py
@@ -13,7 +13,10 @@ from backend.protzilla.data_preprocessing.plots import (
 )
 from backend.protzilla.utilities import default_intensity_column
 from backend.protzilla.utilities.transform_dfs import long_to_wide, wide_to_long
-from backend.protzilla.constants.option_types import SimpleImputerStrategyType, ImputationByNormalDistributionSamplingStrategyType
+from backend.protzilla.constants.option_types import (
+    SimpleImputerStrategyType,
+    ImputationByNormalDistributionSamplingStrategyType,
+)
 
 
 def flag_invalid_values(df: pd.DataFrame, messages: list) -> dict:

--- a/backend/protzilla/data_preprocessing/imputation.py
+++ b/backend/protzilla/data_preprocessing/imputation.py
@@ -13,6 +13,7 @@ from backend.protzilla.data_preprocessing.plots import (
 )
 from backend.protzilla.utilities import default_intensity_column
 from backend.protzilla.utilities.transform_dfs import long_to_wide, wide_to_long
+from backend.protzilla.constants.option_types import SimpleImputerStrategyType
 
 
 def flag_invalid_values(df: pd.DataFrame, messages: list) -> dict:
@@ -121,7 +122,7 @@ def by_simple_imputer(
     :return: returns an imputed dataframe in typical protzilla long format
         a list of messages
     """
-    assert strategy in ["mean", "median", "most_frequent"]
+    assert strategy in {item.value for item in SimpleImputerStrategyType}
     transformed_df = long_to_wide(protein_df)
     transformed_df.dropna(axis=1, how="all", inplace=True)
 
@@ -279,9 +280,9 @@ def by_normal_distribution_sampling(
     :return: returns an imputed dataframe in typical protzilla long format\
     a list of messages
     """
-    assert strategy in ["perProtein", "perDataset"]
+    assert strategy in {item.value for value in ImputationByNormalDistributionSamplingStrategyType}
 
-    if strategy == "perProtein":
+    if strategy == ImputationByNormalDistributionSamplingStrategyType.PER_PROTEIN.value:
         transformed_df = long_to_wide(protein_df)
         # iterate over all protein groups
         for protein_grp in transformed_df.columns:

--- a/backend/protzilla/data_preprocessing/normalisation.py
+++ b/backend/protzilla/data_preprocessing/normalisation.py
@@ -94,26 +94,21 @@ def by_median(
                 quantile
             )
         else:
-            # TODO 428
-            try:
-                raise ValueError(
-                    "\nCareful, your median is zero - we recommend\
-                    \nadapting your filtering strategy or using a higher\
-                    \nquantile for normalisation."
-                )
-            except ValueError:
-                traceback.print_exc()
-                df_sample[f"Normalised {intensity_name}"] = 0
-                zeroed_samples.append(sample)
+            df_sample[f"Normalised {intensity_name}"] = 0
+            zeroed_samples.append(sample)
         df_sample.drop(axis=1, labels=[intensity_name], inplace=True)
         scaled_df = pd.concat([scaled_df, df_sample], ignore_index=True)
 
     pd.reset_option("mode.chained_assignment")
 
-    return dict(
-        protein_df=scaled_df,
-        zeroed_samples=zeroed_samples,
-    )
+    output = dict(protein_df=scaled_df, zeroed_samples=zeroed_samples)
+
+    if zeroed_samples != []:
+        output["messages"] = dict(
+            level=logging.WARNING,
+            msg=f"Samples {zeroed_samples} have median zero - we recommend adapting your filtering strategy or using a higher quantile for normalisation",
+        )
+    return output
 
 
 def by_totalsum(protein_df: pd.DataFrame) -> dict:
@@ -141,7 +136,7 @@ def by_totalsum(protein_df: pd.DataFrame) -> dict:
     intensity_name = default_intensity_column(protein_df)
     scaled_df = pd.DataFrame()
     samples = protein_df["Sample"].unique().tolist()
-    zeroed_samples_list = []
+    zeroed_samples = []
 
     for sample in samples:
         df_sample = protein_df.loc[protein_df["Sample"] == sample,]
@@ -152,24 +147,21 @@ def by_totalsum(protein_df: pd.DataFrame) -> dict:
                 totalsum
             )
         else:
-            # TODO 428
-            try:
-                raise ValueError(
-                    "\nCareful, your total sum is zero. Try using other\
-                    \nfiltering strategies such as filtering non- or low\
-                    \nintensity samples."
-                )
-            except ValueError:
-                traceback.print_exc()
-                df_sample[f"Normalised {intensity_name}"] = 0
-                zeroed_samples_list.append(sample)
+            df_sample[f"Normalised {intensity_name}"] = 0
+            zeroed_samples.append(sample)
 
         df_sample.drop(axis=1, labels=[intensity_name], inplace=True)
 
         scaled_df = pd.concat([scaled_df, df_sample], ignore_index=True)
 
     pd.reset_option("mode.chained_assignment")
-    return dict(protein_df=scaled_df, zeroed_samples=zeroed_samples_list)
+    output = dict(protein_df=scaled_df, zeroed_samples=zeroed_samples)
+    if zeroed_samples != []:
+        output["messages"] = dict(
+            level=logging.WARNING,
+            msg=f"Samples {zeroed_samples} have a sum of zero - try using other filtering strategies such as filtering non- or low intensity samples."
+        )
+    return output
 
 
 def by_width_adjustment(protein_df: pd.DataFrame) -> dict:

--- a/backend/protzilla/data_preprocessing/normalisation.py
+++ b/backend/protzilla/data_preprocessing/normalisation.py
@@ -159,7 +159,7 @@ def by_totalsum(protein_df: pd.DataFrame) -> dict:
     if zeroed_samples != []:
         output["messages"] = dict(
             level=logging.WARNING,
-            msg=f"Samples {zeroed_samples} have a sum of zero - try using other filtering strategies such as filtering non- or low intensity samples."
+            msg=f"Samples {zeroed_samples} have a sum of zero - try using other filtering strategies such as filtering non- or low intensity samples.",
         )
     return output
 

--- a/backend/protzilla/data_preprocessing/outlier_detection.py
+++ b/backend/protzilla/data_preprocessing/outlier_detection.py
@@ -11,7 +11,7 @@ from backend.protzilla.data_preprocessing.plots import (
     create_pca_3d_scatter_plot,
 )
 
-from ..utilities.transform_dfs import long_to_wide
+from backend.protzilla.utilities.transform_dfs import long_to_wide
 
 
 def by_isolation_forest(

--- a/backend/protzilla/data_preprocessing/transformation.py
+++ b/backend/protzilla/data_preprocessing/transformation.py
@@ -20,17 +20,22 @@ def by_inversion(protein_df: pd.DataFrame, peptide_df: pd.DataFrame | None) -> d
     :return: returns a dict containing the transformed dataframes for "protein_df" and "peptide_df" respectively
     :rtype: dict[str, pd.DataFrame | None]
     """
-    intensity_name = default_intensity_column(protein_df)
+    protein_intensity_name = default_intensity_column(protein_df)
+    peptide_intensity_name = (
+        default_intensity_column(peptide_df) if peptide_df is not None else None
+    )
 
     transformed_df = protein_df.copy()
-    transformed_df[intensity_name] = 1 / transformed_df[intensity_name]
-    if np.isinf(transformed_df[intensity_name]).any():
+    transformed_df[protein_intensity_name] = 1 / transformed_df[protein_intensity_name]
+    if np.isinf(transformed_df[protein_intensity_name]).any():
         raise ValueError("Division by zero when inverting values.")
 
     transformed_peptide_df = peptide_df.copy() if peptide_df is not None else None
     if transformed_peptide_df is not None:
-        transformed_peptide_df["Intensity"] = 1 / transformed_peptide_df["Intensity"]
-        if np.isinf(transformed_peptide_df["Intensity"]).any():
+        transformed_peptide_df[peptide_intensity_name] = (
+            1 / transformed_peptide_df[peptide_intensity_name]
+        )
+        if np.isinf(transformed_peptide_df[peptide_intensity_name]).any():
             raise ValueError("Division by zero when inverting values.")
 
     return dict(protein_df=transformed_df, peptide_df=transformed_peptide_df)
@@ -55,6 +60,9 @@ def by_log(
     :rtype: dict[str, pd.DataFrame | None]
     """
     intensity_name = default_intensity_column(protein_df)
+    peptide_intensity_name = (
+        default_intensity_column(peptide_df) if peptide_df is not None else None
+    )
     transformed_df = protein_df.copy()
     transformed_peptide_df = peptide_df.copy() if peptide_df is not None else None
 
@@ -62,14 +70,14 @@ def by_log(
     if log_base == "log2":
         transformed_df[intensity_name] = np.log2(transformed_df[intensity_name])
         if transformed_peptide_df is not None:
-            transformed_peptide_df["Intensity"] = np.log2(
-                transformed_peptide_df["Intensity"]
+            transformed_peptide_df[peptide_intensity_name] = np.log2(
+                transformed_peptide_df[peptide_intensity_name]
             )
     elif log_base == "log10":
         transformed_df[intensity_name] = np.log10(transformed_df[intensity_name])
         if transformed_peptide_df is not None:
-            transformed_peptide_df["Intensity"] = np.log10(
-                transformed_peptide_df["Intensity"]
+            transformed_peptide_df[peptide_intensity_name] = np.log10(
+                transformed_peptide_df[peptide_intensity_name]
             )
     else:
         raise ValueError("Unknown log_base. Known log methods are 'log2' and 'log10'.")

--- a/backend/protzilla/methods/data_preprocessing.py
+++ b/backend/protzilla/methods/data_preprocessing.py
@@ -11,47 +11,7 @@ from backend.protzilla.data_preprocessing import (
 )
 from backend.protzilla.form import *
 from backend.protzilla.steps import Step, StepManager
-
-
-class EmptyEnum(Enum):
-    pass
-
-
-class LogTransformationBaseType(Enum):
-    LOG2 = "log2"
-    LOG10 = "log10"
-
-
-class SimpleImputerStrategyType(Enum):
-    MEAN = "mean"
-    MEDIAN = "median"
-    MOST_FREQUENT = "most_frequent"
-
-
-class ImputationByNormalDistributionSamplingStrategyType(Enum):
-    PER_PROTEIN = "perProtein"
-    PER_DATASET = "perDataset"
-
-
-class BarAndPieChart(Enum):
-    BAR_PLOT = "Bar chart"
-    PIE_CHART = "Pie chart"
-
-
-class BoxAndHistogramGraph(Enum):
-    BOXPLOT = "Boxplot"
-    HISTOGRAM = "Histogram"
-
-
-class GroupBy(Enum):
-    NO_GROUPING = "None"
-    SAMPLE = "Sample"
-    PROTEIN_ID = "Protein ID"
-
-
-class VisualTransformations(Enum):
-    LOG10 = "log10"
-    LINEAR = "linear"
+from backend.protzilla.constants.option_types import *
 
 
 class DataPreprocessingStep(Step):


### PR DESCRIPTION
## Description

fixes #131
clean some minor stuff up in the preprocessing steps and ensure compatibility with SILAC ratios

## Changes
- `backend/protzilla/data_preprocessing/transformation.py`: change `"Intensity"` to the df's intensity column's name
- consistently use form option enums
  - move enum definitions from `backend/protzilla/methods/data_preprocessing.py` to `backend/protzilla/constants/option_types.py`
  - enforce allowed options from the relevant enum in `backend/protzilla/data_preprocessing/imputation.py`
 - fix [#428](https://github.com/cschlaffner/PROTzilla2/issues/428) from the old repo in `backend/protzilla/data_preprocessing/normalisation.py`


## Testing


## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint` (didn't touch it)
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
