### PR TITLE
implement SILAC t-test

### DIFF
--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -633,8 +633,8 @@ def get_step_table(request):
 
         if run.current_step is not None:
             for key, value in run.current_outputs:
-                if key in dataframes:
-                    data = value
+                if isinstance(value, pd.DataFrame):
+                    data = value.copy()
                     data["id"] = data.index
                     cleaned_data = data.replace(np.nan, None)
                     json_data.append(

--- a/backend/protzilla/data_analysis/differential_expression_t_test.py
+++ b/backend/protzilla/data_analysis/differential_expression_t_test.py
@@ -101,6 +101,14 @@ def t_test(
         protein_df = intensity_df[intensity_df["Protein ID"] == protein]
         group1_intensities = protein_df[protein_df[grouping] == group1][intensity_name]
         group2_intensities = protein_df[protein_df[grouping] == group2][intensity_name]
+
+        group1_intensities = group1_intensities.dropna()
+        group2_intensities = group2_intensities.dropna()
+        if len(group1_intensities) < 2 or len(group2_intensities) < 2:
+            if not exists_message(messages, INVALID_PROTEINGROUP_DATA_MSG):
+                messages.append(INVALID_PROTEINGROUP_DATA_MSG)
+            continue
+
         t, p = stats.ttest_ind(
             group1_intensities,
             group2_intensities,

--- a/backend/tests/protzilla/data_analysis/test_differential_expression.py
+++ b/backend/tests/protzilla/data_analysis/test_differential_expression.py
@@ -335,6 +335,49 @@ def test_differential_expression_t_test_with_log_data(show_figures):
     assert log2fc_rounded == log2_fc
 
 
+def test_differential_expression_t_test_with_silac_ratios():
+    silac_ratio_df = pd.DataFrame(
+        data=[
+            ["Sample1", "Protein1", "Gene1", 1.2],
+            ["Sample2", "Protein1", "Gene1", np.nan],
+            ["Sample3", "Protein1", "Gene1", 1.1],
+            ["Sample4", "Protein1", "Gene1", 0.8],
+            ["Sample5", "Protein1", "Gene1", 0.9],
+            ["Sample6", "Protein1", "Gene1", np.nan],
+        ],
+        columns=["Sample", "Protein ID", "Gene", "Ratio H/L"],
+    )
+
+    metadata_df = pd.DataFrame(
+        data=[
+            ["Sample1", "Group1"],
+            ["Sample2", "Group1"],
+            ["Sample3", "Group1"],
+            ["Sample4", "Group2"],
+            ["Sample5", "Group2"],
+            ["Sample6", "Group2"],
+        ],
+        columns=["Sample", "Group"],
+    )
+
+    out = t_test(
+        silac_ratio_df,
+        metadata_df,
+        ttest_type="Welch's t-Test",
+        grouping="Group",
+        group1="Group1",
+        group2="Group2",
+        log_base="None",
+        multiple_testing_correction_method="Benjamini-Hochberg",
+        alpha=0.05,
+    )
+
+    assert not out["corrected_p_values_df"].empty
+    assert out["corrected_p_values_df"]["Protein ID"].tolist() == ["Protein1"]
+    assert round(out["corrected_p_values_df"]["corrected_p_value"].iloc[0], 4) == 0.0513
+    assert round(out["log2_fold_change_df"]["log2_fold_change"].iloc[0], 2) == -0.44
+
+
 def test_differential_expression_anova(show_figures):
     test_intensity_list = (
         ["Sample1", "Protein1", "Gene1", 18],


### PR DESCRIPTION
## Description
fixes one part of #132 
- Make the t-test tolerate SILAC ratios with NaNs and still show its tables.

## Changes
- differential_expression_t_test.py: drop NaNs, require ≥2 values/group.
- test_differential_expression.py: add SILAC ratio regression test (p ≈ 0.0513, log2FC ≈ -0.44).
- views.py: include all *_df outputs in the “Tables” tab.

## Testing
- PYTHONPATH=backend pytest backend/tests/protzilla/data_analysis/test_differential_expression.py -k silac --maxfail=1
- Frontend: run t-test and check tables.
- You can create your own metadata or use the one i created: 
[metadata.csv](https://github.com/user-attachments/files/24424576/metadata.csv)

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.

**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`

**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes

## Known Issues
- If a Table is empty the whole frontend crashes but this was most likely not done through this PR.