### PR TITLE
fix: enum access of preprocessing steps

### DIFF
--- a/backend/protzilla/methods/data_preprocessing.py
+++ b/backend/protzilla/methods/data_preprocessing.py
@@ -88,7 +88,7 @@ class FilterProteinsBySilacRatios(DataPreprocessingStep):
                 DropdownField(
                     name="graph_type",
                     label="Graph type",
-                    value=BarAndPieChart.pie_chart.value,
+                    value=BarAndPieChart.PIE_CHART.value,
                     options=BarAndPieChart,
                 ),
             ],
@@ -500,20 +500,20 @@ class NormalisationByWidthAdjustment(DataPreprocessingStep):
                 DropdownField(
                     name="graph_type",
                     label="Graph type",
-                    value=BoxAndHistogramGraph.boxplot.value,
+                    value=BoxAndHistogramGraph.BOXPLOT.value,
                     options=BoxAndHistogramGraph,
                 ),
                 DropdownField(
                     name="group_by",
                     label="Group by",
-                    value=GroupBy.no_grouping.value,
+                    value=GroupBy.NO_GROUPING.value,
                     options=GroupBy,
                 ),
                 DropdownField(
                     name="visual_transformation",
                     label="Visual transformation",
-                    value=VisualTrasformations.log10.value,
-                    options=VisualTrasformations,
+                    value=VisualTransformations.LOG10.value,
+                    options=VisualTransformations,
                 ),
             ],
         )

--- a/backend/protzilla/steps.py
+++ b/backend/protzilla/steps.py
@@ -323,7 +323,7 @@ class Step:
                 ),
                 DropdownField(
                     name="graph_type",
-                    value=BarAndPieChart.pie_chart,
+                    value=BarAndPieChart.PIE_CHART,
                     label="Graph type",
                     options=BarAndPieChart,
                 ),


### PR DESCRIPTION
## Description
fixes #173

We had recently changed the format of enum fields in the backend, where the fields are now capitalized. Somehow, this wasn't changed in the options of the SILAC filtering and width normalization steps (probably a merging issue)

## Changes

The relevant constants are now correctly accessed.


## Testing

1. start protzilla
2. open any run
3. try to add the mentioned steps
4. observe them doing their things

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint` (didn't touch the frontend)
 
**Code review**
- [x] I have self-reviewed my code.
- [x] At least one other developer reviewed and approved the changes
