### PR TITLE
fix: SILAC ratio filter takes groups into account

### DIFF
--- a/backend/protzilla/data_preprocessing/filter_proteins.py
+++ b/backend/protzilla/data_preprocessing/filter_proteins.py
@@ -1,10 +1,10 @@
 import pandas as pd
 
 from backend.protzilla.data_preprocessing.plots import create_bar_plot, create_pie_plot
-
 from backend.protzilla.utilities.utilities import default_intensity_column
+from backend.protzilla.data_analysis.classification_helper import encode_labels
 
-from ..utilities.transform_dfs import long_to_wide
+from backend.protzilla.utilities.transform_dfs import long_to_wide
 
 
 def by_samples_missing(
@@ -48,13 +48,16 @@ def by_samples_missing(
 
 def by_silac_ratios(
     protein_df: pd.DataFrame,
+    metadata_df: pd.DataFrame,
     peptide_df: pd.DataFrame | None,
     min_amount: int,
 ) -> dict:
     """
-    This function filters proteins based on the amount of samples with unique SILAC ratios.
+    This function filters proteins based on the amount of samples with unique SILAC ratios per group. Only proteins with
+    at least the specified amount of samples in each group are kept.
 
     :param protein_df: the protein dataframe that should be filtered
+    :param metadata_df: the metadata dataframe from which to take group labels
     :param peptide_df: the peptide dataframe that should be filtered in accordance to the intensity dataframe (optional)
     :param min_amount: defines the minimum amount of samples the protein has to have a unique intensity in (inclusive)
     :return: returns the filtered df as a Dataframe and a dict with a list of Protein IDs that were discarded
@@ -62,7 +65,13 @@ def by_silac_ratios(
     """
 
     intensity_name = default_intensity_column(protein_df)
-    unique_ratio_count = protein_df.groupby("Protein ID")[intensity_name].nunique()
+    labeled_df = pd.merge(protein_df, metadata_df, on="Sample", how="left")
+    unique_ratio_count = (
+        labeled_df.groupby(["Protein ID", "Group"])[intensity_name]
+        .nunique()
+        .groupby("Protein ID")
+        .min()
+    )
     remaining_proteins_list = unique_ratio_count[
         unique_ratio_count >= min_amount
     ].index.tolist()

--- a/backend/protzilla/data_preprocessing/filter_proteins.py
+++ b/backend/protzilla/data_preprocessing/filter_proteins.py
@@ -2,7 +2,6 @@ import pandas as pd
 
 from backend.protzilla.data_preprocessing.plots import create_bar_plot, create_pie_plot
 from backend.protzilla.utilities.utilities import default_intensity_column
-from backend.protzilla.data_analysis.classification_helper import encode_labels
 
 from backend.protzilla.utilities.transform_dfs import long_to_wide
 

--- a/backend/protzilla/methods/data_preprocessing.py
+++ b/backend/protzilla/methods/data_preprocessing.py
@@ -68,7 +68,7 @@ class FilterProteinsBySamplesMissing(DataPreprocessingStep):
 class FilterProteinsBySilacRatios(DataPreprocessingStep):
     display_name = "By SILAC ratios"
     operation = "filter_proteins"
-    method_description = "Filter proteins based on the minumum amount of samples with different SILAC different ratios in each group"
+    method_description = "Filter proteins based on the minimum amount of samples with different SILAC ratios in each group"
 
     input_keys = ["protein_df", "peptide_df", "min_amount"]
 

--- a/backend/protzilla/methods/data_preprocessing.py
+++ b/backend/protzilla/methods/data_preprocessing.py
@@ -70,7 +70,7 @@ class FilterProteinsBySilacRatios(DataPreprocessingStep):
     operation = "filter_proteins"
     method_description = "Filter proteins based on the minumum amount of samples with different SILAC different ratios in each group"
 
-    # input_keys = ["protein_df", "peptide_df", "min_amount"]
+    input_keys = ["protein_df", "peptide_df", "min_amount"]
 
     def create_form(self):
         return Form(

--- a/backend/protzilla/methods/data_preprocessing.py
+++ b/backend/protzilla/methods/data_preprocessing.py
@@ -68,11 +68,9 @@ class FilterProteinsBySamplesMissing(DataPreprocessingStep):
 class FilterProteinsBySilacRatios(DataPreprocessingStep):
     display_name = "By SILAC ratios"
     operation = "filter_proteins"
-    method_description = (
-        "Filter proteins based on the amount of samples with SILAC different ratios"
-    )
+    method_description = "Filter proteins based on the minumum amount of samples with different SILAC different ratios in each group"
 
-    input_keys = ["protein_df", "peptide_df", "min_amount"]
+    # input_keys = ["protein_df", "peptide_df", "min_amount"]
 
     def create_form(self):
         return Form(
@@ -80,7 +78,7 @@ class FilterProteinsBySilacRatios(DataPreprocessingStep):
             input_fields=[
                 NumberField(
                     name="min_amount",
-                    label="Amount of minimum present samples with different SILAC ratios",
+                    label="Amount of minimum present samples per group with different SILAC ratios",
                     value=1,
                     min=0,
                     step=1,
@@ -93,6 +91,12 @@ class FilterProteinsBySilacRatios(DataPreprocessingStep):
                 ),
             ],
         )
+
+    def insert_dataframes(self, steps: StepManager, inputs: dict) -> dict:
+        inputs["protein_df"] = steps.protein_df
+        inputs["peptide_df"] = steps.get_step_output(Step, "peptide_df")
+        inputs["metadata_df"] = steps.get_step_output(Step, "metadata_df")
+        return inputs
 
     calc_method = staticmethod(filter_proteins.by_silac_ratios)
     plot_method = staticmethod(filter_proteins.by_silac_ratios_plot)

--- a/backend/tests/protzilla/data_preprocessing/test_filter_proteins.py
+++ b/backend/tests/protzilla/data_preprocessing/test_filter_proteins.py
@@ -93,7 +93,7 @@ def filter_proteins_by_silac_ratios_df():
             ["Sample4", "Protein3", "Gene3", 0.85],
             ["Sample1", "Protein4", "Gene4", np.nan],
             ["Sample2", "Protein4", "Gene4", 0.51],
-            ["Sample3", "Protein4", "Gene4", np.nan],
+            ["Sample3", "Protein4", "Gene4", 0.9],
             ["Sample4", "Protein1", "Gene1", 0.25],
         ),
         columns=["Sample", "Protein ID", "Gene", "Ratio H/L"],
@@ -104,6 +104,16 @@ def filter_proteins_by_silac_ratios_df():
     )
 
     return filter_proteins_df
+
+
+@pytest.fixture
+def filter_proteins_by_silac_ratios_metadata_df():
+    return pd.DataFrame(
+        {
+            "Group": ["POS", "NEG", "NEG", "POS"],
+            "Sample": ["Sample1", "Sample2", "Sample3", "Sample4"],
+        }
+    )
 
 
 def test_filter_proteins_by_missing_samples(
@@ -157,11 +167,17 @@ def test_filter_proteins_by_missing_samples(
 
 
 def test_filter_proteins_by_silac_ratios(
-    filter_proteins_by_silac_ratios_df, peptides_df, show_figures
+    filter_proteins_by_silac_ratios_df,
+    filter_proteins_by_silac_ratios_metadata_df,
+    peptides_df,
+    show_figures,
 ):
 
     method_output = by_silac_ratios(
-        filter_proteins_by_silac_ratios_df, peptide_df=None, min_amount=2
+        filter_proteins_by_silac_ratios_df,
+        filter_proteins_by_silac_ratios_metadata_df,
+        peptide_df=None,
+        min_amount=2,
     )
 
     fig = by_silac_ratios_plot(
@@ -172,18 +188,29 @@ def test_filter_proteins_by_silac_ratios(
     if show_figures:
         fig.show()
 
-    assert method_output["remaining_proteins"] == ["Protein3", "Protein4"]
-    assert method_output["filtered_proteins"] == ["Protein1", "Protein2"]
-
-    method_output = by_silac_ratios(
-        filter_proteins_by_silac_ratios_df, peptide_df=None, min_amount=4
-    )
-
     assert method_output["remaining_proteins"] == ["Protein3"]
     assert method_output["filtered_proteins"] == ["Protein1", "Protein2", "Protein4"]
 
     method_output = by_silac_ratios(
-        filter_proteins_by_silac_ratios_df, peptide_df=peptides_df, min_amount=4
+        filter_proteins_by_silac_ratios_df,
+        filter_proteins_by_silac_ratios_metadata_df,
+        peptide_df=None,
+        min_amount=4,
+    )
+
+    assert method_output["remaining_proteins"] == []
+    assert method_output["filtered_proteins"] == [
+        "Protein1",
+        "Protein2",
+        "Protein3",
+        "Protein4",
+    ]
+
+    method_output = by_silac_ratios(
+        filter_proteins_by_silac_ratios_df,
+        filter_proteins_by_silac_ratios_metadata_df,
+        peptide_df=peptides_df,
+        min_amount=4,
     )
 
     assert_peptide_filtering_matches_protein_filtering(


### PR DESCRIPTION
## Description

fixes #177
The SILAC ratio filter had been incorrectly implemented (at least in respect to the AML paper). Instead counting the amount of different SILAC values for each protein across the entire `protein_df`, the filter now depends on the minimum number of SILAC ratios per protein _per group_, which is how the authors of the paper filtered.

## Changes

- taken from #174 (otherwise, the SILAC filter doesn't work):
  - change enum fields to their new names (already approved in the other PR)

- this PR:
  - `backend/protzilla/data_preprocessing/filter_proteins.py`: adapt the calculation method and its docstring
  - `backend/protzilla/methods/data_preprocessing.py`: insert the `metadata_df` by overriding `insert_dataframe`, adapt the user-facing strings in the form
  - `backend/tests/protzilla/data_preprocessing/test_filter_proteins.py`: update tests with mock metadata


## Testing

(will mark ready for review once I have the relevant files)
1. import [this run](https://nextcloud.hpi.de/f/33072489) that was prepared to match the 
2. (optional) import the [protein groups](https://nextcloud.hpi.de/f/33072480) (they're already imported in the prepared run, but the step is missing - there is some filtering happening that protzilla doesnt't support yet)
3. replace the _Filter Samples by Proteins Missing_ step with _Filter Proteins by SILAC ratios_
4. set the threshold to 5
5. see exactly 5309 remaining proteins, just like in the [paper](https://www.mdpi.com/2072-6694/12/3/709#Results), section 2.2

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint` (didn't touch it, but the CI is happy)
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
