### PR TITLE
196 add persistence option

### DIFF
--- a/backend/protzilla/importing/alphafold_protein_structure_load.py
+++ b/backend/protzilla/importing/alphafold_protein_structure_load.py
@@ -6,6 +6,9 @@ from typing import Any
 import pandas as pd
 import requests
 from textwrap import wrap
+from CifFile import ReadCif
+import shutil
+import tempfile
 
 
 from backend.protzilla.constants import paths
@@ -40,6 +43,149 @@ def to_fasta(seq: str, header: str = "protein_sequence", width: int = 60) -> str
     if bad:
         raise ValueError(f"Invalid characters in sequence: {''.join(sorted(bad))}")
     return ">" + header + "\n" + "\n".join(wrap(seq, width)) + "\n"
+
+
+def fasta_to_dataframe(fasta_path: str):
+    records = []
+    seq_id = None
+    seq = []
+
+    with open(fasta_path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith(">"):
+                if seq_id is not None:
+                    sequence = "".join(seq)
+                    records.append({
+                        "id": seq_id,
+                        "sequence": sequence,
+                        "length": len(sequence),
+                    })
+                seq_id = line[1:].split()[0]
+                seq = []
+            else:
+                seq.append(line)
+
+        if seq_id is not None:
+            sequence = "".join(seq)
+            records.append({
+                "id": seq_id,
+                "sequence": sequence,
+                "length": len(sequence),
+            })
+
+    return pd.DataFrame(records)
+
+
+def cif_to_dataframe(cif_path):
+    cif = ReadCif(str(cif_path))
+    block = cif.first_block()
+
+    df = pd.DataFrame({
+        "label": block["_atom_site_label"],
+        "element": block["_atom_site_type_symbol"],
+        "x": block["_atom_site_fract_x"],
+        "y": block["_atom_site_fract_y"],
+        "z": block["_atom_site_fract_z"],
+    })
+
+    return df
+
+
+def _handle_alphafold_files(
+    session: requests.Session,
+    files_urls: dict[str, Any],
+    uniprot: str,
+    seq: str,
+    metadata_df: pd.DataFrame,
+    acc: str,
+    persist_upload: bool = False,
+) -> tuple[
+    dict[str, str],
+    Path,
+    pd.DataFrame,
+    pd.DataFrame,
+    pd.DataFrame,
+    pd.DataFrame,
+]:
+    """
+    Either the files are persistently saved on disk and loaded into dataframes or only loaded into dataframes to be used only for the current run.
+    """
+    cif_df = None
+    pae_df = None
+    plddt_df = None
+    sequence_df = None
+
+    meta_dir = paths.EXTERNAL_DATA_PATH / "alphafold"
+    target_dir = meta_dir / (acc or uniprot)
+    downloaded: dict[str, str] = {}
+
+    temp_dir = None
+    work_dir = target_dir
+
+    if persist_upload:
+        target_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        temp_dir = Path(tempfile.mkdtemp())
+        work_dir = temp_dir
+
+    try:
+        if persist_upload and metadata_df is not None:
+            meta_dir.mkdir(parents=True, exist_ok=True)
+            metadata_csv = meta_dir / "alphafold_metadata.csv"
+            try:
+                if metadata_csv.exists():
+                    existing = pd.read_csv(metadata_csv, dtype=str)
+                    if acc and "uniprotAccession" in existing.columns:
+                        existing = existing[existing["uniprotAccession"] != acc]
+                    combined = pd.concat([existing, metadata_df], ignore_index=True)
+                    combined.to_csv(metadata_csv, index=False)
+                else:
+                    metadata_df.to_csv(metadata_csv, index=False)
+                logger.info("Wrote AlphaFold metadata to %s", metadata_csv)
+            except Exception:
+                logger.exception(
+                    "Failed to write AlphaFold metadata CSV to %s", metadata_csv
+                )
+
+        for key in ("cifUrl", "paeDocUrl", "plddtDocUrl"):
+            urlval = files_urls.get(key)
+            if isinstance(urlval, str) and urlval:
+                fname = urlval.split("?")[0].rstrip("/").split("/")[-1]
+                dest = work_dir / fname
+                saved = _download_file(session, urlval, dest)
+                if saved:
+                    downloaded[key] = str(saved)
+                    try:
+                        if key == "cifUrl":
+                            cif_df = cif_to_dataframe(saved)
+                        elif key == "paeDocUrl":
+                            pae_df = pd.read_json(saved)
+                        elif key == "plddtDocUrl":
+                            plddt_df = pd.read_json(saved)
+                    except Exception:
+                        logger.exception("Failed to load %s into dataframe", key)
+
+        sequence = to_fasta(seq=seq, header=uniprot)
+        fasta_dest = work_dir / f"{uniprot.upper()}.fasta"
+        try:
+            fasta_dest.parent.mkdir(parents=True, exist_ok=True)
+            with open(fasta_dest, "w") as f:
+                f.write(sequence)
+            logger.info("Wrote FASTA sequence to %s", fasta_dest)
+            sequence_df = fasta_to_dataframe(str(fasta_dest))
+        except OSError:
+            logger.exception("Failed to write FASTA file %s", fasta_dest)
+        except Exception:
+            logger.exception("Failed to create sequence dataframe")
+
+    finally:
+        if temp_dir is not None:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    return cif_df, pae_df, plddt_df, sequence_df
 
 
 def fetch_alphafold_protein_structure(uniprot: str, persistUploads: bool,) -> dict[str, Any]:
@@ -78,51 +224,16 @@ def fetch_alphafold_protein_structure(uniprot: str, persistUploads: bool,) -> di
             if isinstance(r.get(key), str) and r.get(key):
                 files_urls[key] = r[key]
 
-        alphafold_df = pd.DataFrame([data])
+        metadata_df = pd.DataFrame([data])
         acc = data.get("uniprotAccession")
-        if persistUploads:
-            # prefer reading the existing AlphaFold metadata CSV into the dataframe
-            meta_dir = paths.EXTERNAL_DATA_PATH / "alphafold"
-            meta_dir.mkdir(parents=True, exist_ok=True)
-            metadata_csv = meta_dir / "alphafold_metadata.csv"
 
-            try:
-                if metadata_csv.exists():
-                    existing = pd.read_csv(metadata_csv, dtype=str)
-                    if acc and "uniprotAccession" in existing.columns:
-                        existing = existing[existing["uniprotAccession"] != acc]
-                    combined = pd.concat([existing, alphafold_df], ignore_index=True)
-                    combined.to_csv(metadata_csv, index=False)
-                else:
-                    alphafold_df.to_csv(metadata_csv, index=False)
-                logger.info("Wrote AlphaFold metadata to %s", metadata_csv)
-            except Exception:
-                logger.exception(
-                    "Failed to write AlphaFold metadata CSV to %s", metadata_csv
-                )
-            downloaded: dict[str, str] = {}
-
-            target_dir = meta_dir / (acc or uniprot)
-
-            for key in ("cifUrl", "pdbUrl", "paeDocUrl", "plddtDocUrl"):
-                urlval = files_urls.get(key)
-                if isinstance(urlval, str) and urlval:
-                    fname = urlval.split("?")[0].rstrip("/").split("/")[-1]
-                    dest = target_dir / fname
-                    saved = _download_file(session, urlval, dest)
-                    if saved:
-                        downloaded[key] = str(saved)
-            
-            sequence = to_fasta(seq=seq_tmp, header=uniprot)
-            dest = target_dir / f"{uniprot.upper()}.fasta"
-
-            with open(dest, "w") as f:
-                f.write(sequence)
-        else:
-            pass
+        cif_df, pae_df, plddt_df, sequence_df = _handle_alphafold_files(session=session, files_urls=files_urls, uniprot=uniprot, seq=seq_tmp, metadata_df=metadata_df, acc=acc, persist_upload=persistUploads)
+        
 
         return {
-            "alphafold_df": alphafold_df,
-            "metadata_csv": str(metadata_csv),
-            "downloaded_files": downloaded,
+            "metadata_df": metadata_df,
+            "cif_df": cif_df,
+            "pae_df": pae_df,
+            "plddt_df": plddt_df,
+            "sequence_df": sequence_df,
         }

--- a/backend/protzilla/importing/alphafold_protein_structure_load.py
+++ b/backend/protzilla/importing/alphafold_protein_structure_load.py
@@ -196,29 +196,29 @@ def fetch_alphafold_protein_structure(
     Retrieves metadata and structure files (CIF, PAE, pLDDT) from the AlphaFold Database
     for the given UniProt ID. Optionally persists the downloaded files to disk.
 
-    :param uniprot: The UniProt ID of the protein
+    :param uniprot_id: The UniProt ID of the protein
     :param persist_uploads: If True, files are saved persistently; if False, only loaded into memory
     :return: A dictionary containing DataFrames for metadata, CIF, PAE, pLDDT, and sequence data
     :raises RuntimeError: If the API request fails or returns invalid data
     :raises ValueError: If no predictions are found for the given UniProt ID
     """
-    url = f"https://alphafold.ebi.ac.uk/api/prediction/{uniprot}"
+    url = f"https://alphafold.ebi.ac.uk/api/prediction/{uniprot_id}"
     with requests.Session() as session:
         try:
             resp = session.get(url, timeout=30)
             resp.raise_for_status()
             records = resp.json()
         except requests.RequestException as e:
-            raise RuntimeError(f"AlphaFold request failed for {uniprot}: {e}") from e
+            raise RuntimeError(f"AlphaFold request failed for {uniprot_id}: {e}") from e
         except ValueError as e:
-            raise RuntimeError(f"AlphaFold returned non-JSON for {uniprot}: {e}") from e
+            raise RuntimeError(f"AlphaFold returned non-JSON for {uniprot_id}: {e}") from e
 
         if not isinstance(records, list) or not records:
-            raise ValueError(f"No AlphaFold DB predictions for {uniprot}")
+            raise ValueError(f"No AlphaFold DB predictions for {uniprot_id}")
 
         r = records[0]
         if not isinstance(r, dict):
-            raise RuntimeError(f"Unexpected AlphaFold payload for {uniprot}")
+            raise RuntimeError(f"Unexpected AlphaFold payload for {uniprot_id}")
 
         data: dict[str, Any] = {
             "entryID": r.get("uniprotAccession"),
@@ -241,7 +241,7 @@ def fetch_alphafold_protein_structure(
 
         alpha_dfs = handle_alphafold_files(
             files_urls=files_urls,
-            uniprot=uniprot,
+            uniprot=uniprot_id,
             seq=seq_tmp,
             metadata_df=metadata_df,
             acc=acc,

--- a/backend/protzilla/importing/alphafold_protein_structure_load.py
+++ b/backend/protzilla/importing/alphafold_protein_structure_load.py
@@ -5,6 +5,8 @@ from typing import Any
 
 import pandas as pd
 import requests
+from textwrap import wrap
+
 
 from backend.protzilla.constants import paths
 from backend.protzilla.constants.protzilla_logging import logger
@@ -29,7 +31,18 @@ def _download_file(session: requests.Session, url: str, dest: Path) -> Path | No
         return None
 
 
-def fetch_alphafold_protein_structure(uniprot: str) -> dict[str, Any]:
+def to_fasta(seq: str, header: str = "protein_sequence", width: int = 60) -> str:
+    VALID_AA = set("ACDEFGHIKLMNPQRSTVWYBXZJUO*-")
+    if not seq or any(c.isspace() for c in seq):
+        raise ValueError("Sequence must be a single, whitespace-free string.")
+    seq = seq.upper()
+    bad = set(seq) - VALID_AA
+    if bad:
+        raise ValueError(f"Invalid characters in sequence: {''.join(sorted(bad))}")
+    return ">" + header + "\n" + "\n".join(wrap(seq, width)) + "\n"
+
+
+def fetch_alphafold_protein_structure(uniprot: str, persistUploads: bool,) -> dict[str, Any]:
     url = f"https://alphafold.ebi.ac.uk/api/prediction/{uniprot}"
 
     with requests.Session() as session:
@@ -50,57 +63,63 @@ def fetch_alphafold_protein_structure(uniprot: str) -> dict[str, Any]:
             raise RuntimeError(f"Unexpected AlphaFold payload for {uniprot}")
 
         data: dict[str, Any] = {
-            "entryId": r.get("entryId"),
+            "entryID": r.get("uniprotAccession"),
             "uniprotAccession": r.get("uniprotAccession"),
-            "uniprotId": r.get("uniprotId"),
             "modelCreatedDate": r.get("modelCreatedDate"),
-            "latestVersion": r.get("latestVersion"),
-            "uniprotStart": r.get("uniprotStart"),
-            "uniprotEnd": r.get("uniprotEnd"),
-            "sequenceLength": (
-                len(r["uniprotSequence"])
-                if isinstance(r.get("uniprotSequence"), str)
-                else None
-            ),
+            "gene": r.get("gene"),
+            "alphafold_version": r.get("toolUsed"),
         }
+
+        seq_tmp = r.get("sequence")
 
         files_urls: dict[str, Any] = {}
 
-        for key in ("pdbUrl", "cifUrl", "paeDocUrl", "plddtDocUrl"):
+        for key in ("cifUrl", "paeDocUrl", "plddtDocUrl"):
             if isinstance(r.get(key), str) and r.get(key):
                 files_urls[key] = r[key]
 
-        # prefer reading the existing AlphaFold metadata CSV into the dataframe
-        meta_dir = paths.EXTERNAL_DATA_PATH / "alphafold"
-        meta_dir.mkdir(parents=True, exist_ok=True)
-        metadata_csv = meta_dir / "alphafold_metadata.csv"
-
         alphafold_df = pd.DataFrame([data])
-        try:
-            if metadata_csv.exists():
-                existing = pd.read_csv(metadata_csv, dtype=str)
-                acc = data.get("uniprotAccession")
-                if acc and "uniprotAccession" in existing.columns:
-                    existing = existing[existing["uniprotAccession"] != acc]
-                combined = pd.concat([existing, alphafold_df], ignore_index=True)
+        acc = data.get("uniprotAccession")
+        if persistUploads:
+            # prefer reading the existing AlphaFold metadata CSV into the dataframe
+            meta_dir = paths.EXTERNAL_DATA_PATH / "alphafold"
+            meta_dir.mkdir(parents=True, exist_ok=True)
+            metadata_csv = meta_dir / "alphafold_metadata.csv"
 
-            combined.to_csv(metadata_csv, index=False)
-            logger.info("Wrote AlphaFold metadata to %s", metadata_csv)
-        except Exception:
-            logger.exception(
-                "Failed to write AlphaFold metadata CSV to %s", metadata_csv
-            )
-        downloaded: dict[str, str] = {}
+            try:
+                if metadata_csv.exists():
+                    existing = pd.read_csv(metadata_csv, dtype=str)
+                    if acc and "uniprotAccession" in existing.columns:
+                        existing = existing[existing["uniprotAccession"] != acc]
+                    combined = pd.concat([existing, alphafold_df], ignore_index=True)
+                    combined.to_csv(metadata_csv, index=False)
+                else:
+                    alphafold_df.to_csv(metadata_csv, index=False)
+                logger.info("Wrote AlphaFold metadata to %s", metadata_csv)
+            except Exception:
+                logger.exception(
+                    "Failed to write AlphaFold metadata CSV to %s", metadata_csv
+                )
+            downloaded: dict[str, str] = {}
 
-        target_dir = meta_dir / (data.get("uniprotAccession") or uniprot)
-        for key in ("cifUrl", "pdbUrl", "paeDocUrl", "plddtDocUrl"):
-            urlval = files_urls.get(key)
-            if isinstance(urlval, str) and urlval:
-                fname = urlval.split("?")[0].rstrip("/").split("/")[-1]
-                dest = target_dir / fname
-                saved = _download_file(session, urlval, dest)
-                if saved:
-                    downloaded[key] = str(saved)
+            target_dir = meta_dir / (acc or uniprot)
+
+            for key in ("cifUrl", "pdbUrl", "paeDocUrl", "plddtDocUrl"):
+                urlval = files_urls.get(key)
+                if isinstance(urlval, str) and urlval:
+                    fname = urlval.split("?")[0].rstrip("/").split("/")[-1]
+                    dest = target_dir / fname
+                    saved = _download_file(session, urlval, dest)
+                    if saved:
+                        downloaded[key] = str(saved)
+            
+            sequence = to_fasta(seq=seq_tmp, header=uniprot)
+            dest = target_dir / f"{uniprot.upper()}.fasta"
+
+            with open(dest, "w") as f:
+                f.write(sequence)
+        else:
+            pass
 
         return {
             "alphafold_df": alphafold_df,

--- a/backend/protzilla/importing/alphafold_protein_structure_load.py
+++ b/backend/protzilla/importing/alphafold_protein_structure_load.py
@@ -12,33 +12,8 @@ import requests
 
 from backend.protzilla.constants import paths
 from backend.protzilla.constants.protzilla_logging import logger
-
-
-def _download_file(session: requests.Session, url: str, dest: Path) -> Path | None:
-    """
-    Download a file from a URL and save it to the specified destination path.
-
-    :param session: The requests session to use for the download
-    :param url: The URL of the file to download
-    :param dest: The destination path where the file should be saved
-    :return: The destination path if successful, None otherwise
-    """
-    try:
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        with session.get(url, stream=True, timeout=60) as r:
-            r.raise_for_status()
-            with open(dest, "wb") as f:
-                for chunk in r.iter_content(chunk_size=8192):
-                    if chunk:
-                        f.write(chunk)
-        logger.info("Downloaded %s -> %s", url, dest)
-        return dest
-    except requests.RequestException:
-        logger.exception("Failed to download %s", url)
-        return None
-    except OSError:
-        logger.exception("Failed to write file %s", dest)
-        return None
+from backend.protzilla.importing.fasta_import import fasta_import
+from backend.protzilla.networking import download_file_from_url
 
 
 def to_fasta(seq: str, header: str = "protein_sequence", width: int = 60) -> str:
@@ -51,58 +26,15 @@ def to_fasta(seq: str, header: str = "protein_sequence", width: int = 60) -> str
     :return: The sequence in FASTA format
     :raises ValueError: If the sequence contains invalid characters or whitespace
     """
-    VALID_AA = set("ACDEFGHIKLMNPQRSTVWYBXZJUO*-")
+    VALID_AMINO_ACID = set("ACDEFGHIKLMNPQRSTVWYBXZJUO*-")
     if not seq or any(c.isspace() for c in seq):
         raise ValueError("Sequence must be a single, whitespace-free string.")
     seq = seq.upper()
-    bad = set(seq) - VALID_AA
+    bad = set(seq) - VALID_AMINO_ACID
     if bad:
         raise ValueError(f"Invalid characters in sequence: {''.join(sorted(bad))}")
-    return ">" + header + "\n" + "\n".join(wrap(seq, width)) + "\n"
-
-
-def fasta_to_dataframe(fasta_path: str) -> pd.DataFrame:
-    """
-    Parse a FASTA file and convert it to a DataFrame.
-
-    :param fasta_path: The path to the FASTA file
-    :return: A DataFrame with columns 'id', 'sequence', and 'length'
-    """
-    records = []
-    seq_id = None
-    seq = []
-
-    with open(fasta_path, "r") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            if line.startswith(">"):
-                if seq_id is not None:
-                    sequence = "".join(seq)
-                    records.append(
-                        {
-                            "id": seq_id,
-                            "sequence": sequence,
-                            "length": len(sequence),
-                        }
-                    )
-                seq_id = line[1:].split()[0]
-                seq = []
-            else:
-                seq.append(line)
-
-        if seq_id is not None:
-            sequence = "".join(seq)
-            records.append(
-                {
-                    "id": seq_id,
-                    "sequence": sequence,
-                    "length": len(sequence),
-                }
-            )
-
-    return pd.DataFrame(records)
+    joined = "\n".join(wrap(seq, width))
+    return f">alpha|{header}\n{joined}\n"
 
 
 def read_alphafold_mmcif(path: str) -> pd.DataFrame:
@@ -151,20 +83,14 @@ def read_alphafold_mmcif(path: str) -> pd.DataFrame:
     return pd.DataFrame(data)
 
 
-def _handle_alphafold_files(
-    session: requests.Session,
+def handle_alphafold_files(
     files_urls: dict[str, Any],
     uniprot: str,
     seq: str,
     metadata_df: pd.DataFrame,
     acc: str,
     persist_upload: bool = False,
-) -> tuple[
-    pd.DataFrame | None,
-    pd.DataFrame | None,
-    pd.DataFrame | None,
-    pd.DataFrame | None,
-]:
+) -> dict[str, pd.DataFrame | None]:
     """
     Download AlphaFold structure files and convert them to DataFrames.
 
@@ -172,7 +98,6 @@ def _handle_alphafold_files(
     The function downloads CIF, PAE, and pLDDT files, converts them to DataFrames, and optionally
     saves metadata to a CSV file.
 
-    :param session: The requests session to use for downloading files
     :param files_urls: Dictionary containing URLs for CIF, PAE, and pLDDT files
     :param uniprot: The UniProt ID of the protein
     :param seq: The protein sequence
@@ -187,14 +112,14 @@ def _handle_alphafold_files(
     sequence_df = None
 
     meta_dir = paths.EXTERNAL_DATA_PATH / "alphafold"
-    target_dir = meta_dir / (acc or uniprot)
+    target_dir = meta_dir / uniprot
     downloaded: dict[str, str] = {}
 
     temp_dir = None
-    work_dir = target_dir
 
     if persist_upload:
         target_dir.mkdir(parents=True, exist_ok=True)
+        work_dir = target_dir
     else:
         temp_dir = Path(tempfile.mkdtemp())
         work_dir = temp_dir
@@ -223,19 +148,12 @@ def _handle_alphafold_files(
             if isinstance(urlval, str) and urlval:
                 fname = urlval.split("?")[0].rstrip("/").split("/")[-1]
                 dest = work_dir / fname
-                saved = _download_file(session, urlval, dest)
+                saved = download_file_from_url(urlval, dest)
                 if saved:
                     downloaded[key] = str(saved)
                     try:
                         if key == "cifUrl":
-                            try:
-                                cif_df = read_alphafold_mmcif(str(saved))
-                            except Exception:
-                                logger.exception(
-                                    "Failed to load CIF into dataframe. Path=%s",
-                                    str(saved),
-                                )
-                                raise
+                            cif_df = read_alphafold_mmcif(saved)
                         elif key == "paeDocUrl":
                             pae_df = pd.read_json(saved)
                         elif key == "plddtDocUrl":
@@ -250,7 +168,8 @@ def _handle_alphafold_files(
             with open(fasta_dest, "w") as f:
                 f.write(sequence)
             logger.info("Wrote FASTA sequence to %s", fasta_dest)
-            sequence_df = fasta_to_dataframe(str(fasta_dest))
+            fasta_dict = fasta_import(str(fasta_dest))
+            sequence_df = fasta_dict["fasta_df"]
         except OSError:
             logger.exception("Failed to write FASTA file %s", fasta_dest)
         except Exception:
@@ -260,7 +179,10 @@ def _handle_alphafold_files(
         if temp_dir is not None:
             shutil.rmtree(temp_dir, ignore_errors=True)
 
-    return cif_df, pae_df, plddt_df, sequence_df
+    return {"cif_df":cif_df, 
+            "pae_df": pae_df,
+            "plddt_df": plddt_df, 
+            "sequence_df": sequence_df}
 
 
 def fetch_alphafold_protein_structure(
@@ -315,8 +237,7 @@ def fetch_alphafold_protein_structure(
         metadata_df = pd.DataFrame([data])
         acc = data.get("uniprotAccession")
 
-        cif_df, pae_df, plddt_df, sequence_df = _handle_alphafold_files(
-            session=session,
+        alpha_dfs = handle_alphafold_files(
             files_urls=files_urls,
             uniprot=uniprot,
             seq=seq_tmp,
@@ -327,8 +248,8 @@ def fetch_alphafold_protein_structure(
 
         return {
             "metadata_df": metadata_df,
-            "cif_df": cif_df,
-            "pae_df": pae_df,
-            "plddt_df": plddt_df,
-            "sequence_df": sequence_df,
+            "cif_df": alpha_dfs["cif_df"],
+            "pae_df": alpha_dfs["pae_df"],
+            "plddt_df": alpha_dfs["plddt_df"],
+            "sequence_df": alpha_dfs["sequence_df"],
         }

--- a/backend/protzilla/importing/alphafold_protein_structure_load.py
+++ b/backend/protzilla/importing/alphafold_protein_structure_load.py
@@ -188,7 +188,7 @@ def handle_alphafold_files(
 
 
 def fetch_alphafold_protein_structure(
-    uniprot: str, persist_uploads: bool
+    uniprot_id: str, persist_uploads: bool
 ) -> dict[str, Any]:
     """
     Fetch AlphaFold protein structure data from the AlphaFold Database API.

--- a/backend/protzilla/importing/alphafold_protein_structure_load.py
+++ b/backend/protzilla/importing/alphafold_protein_structure_load.py
@@ -89,7 +89,7 @@ def handle_alphafold_files(
     seq: str,
     metadata_df: pd.DataFrame,
     acc: str,
-    persist_upload: bool = False,
+    persist_uploads: bool = False,
 ) -> dict[str, pd.DataFrame | None]:
     """
     Download AlphaFold structure files and convert them to DataFrames.
@@ -103,7 +103,7 @@ def handle_alphafold_files(
     :param seq: The protein sequence
     :param metadata_df: DataFrame containing AlphaFold metadata
     :param acc: The accession number (used for directory naming)
-    :param persist_upload: If True, files are saved persistently; if False, only loaded into memory
+    :param persist_uploads: If True, files are saved persistently; if False, only loaded into memory
     :return: Tuple of (cif_df, pae_df, plddt_df, sequence_df) or None values for failed loads
     """
     cif_df = None
@@ -117,7 +117,7 @@ def handle_alphafold_files(
 
     temp_dir = None
 
-    if persist_upload:
+    if persist_uploads:
         target_dir.mkdir(parents=True, exist_ok=True)
         work_dir = target_dir
     else:
@@ -125,7 +125,7 @@ def handle_alphafold_files(
         work_dir = temp_dir
 
     try:
-        if persist_upload and metadata_df is not None:
+        if persist_uploads and metadata_df is not None:
             meta_dir.mkdir(parents=True, exist_ok=True)
             metadata_csv = meta_dir / "alphafold_metadata.csv"
             try:
@@ -179,10 +179,12 @@ def handle_alphafold_files(
         if temp_dir is not None:
             shutil.rmtree(temp_dir, ignore_errors=True)
 
-    return {"cif_df":cif_df, 
-            "pae_df": pae_df,
-            "plddt_df": plddt_df, 
-            "sequence_df": sequence_df}
+    return {
+        "cif_df": cif_df,
+        "pae_df": pae_df,
+        "plddt_df": plddt_df,
+        "sequence_df": sequence_df,
+    }
 
 
 def fetch_alphafold_protein_structure(
@@ -243,7 +245,7 @@ def fetch_alphafold_protein_structure(
             seq=seq_tmp,
             metadata_df=metadata_df,
             acc=acc,
-            persist_upload=persist_uploads,
+            persist_uploads=persist_uploads,
         )
 
         return {

--- a/backend/protzilla/importing/alphafold_protein_structure_load.py
+++ b/backend/protzilla/importing/alphafold_protein_structure_load.py
@@ -211,7 +211,9 @@ def fetch_alphafold_protein_structure(
         except requests.RequestException as e:
             raise RuntimeError(f"AlphaFold request failed for {uniprot_id}: {e}") from e
         except ValueError as e:
-            raise RuntimeError(f"AlphaFold returned non-JSON for {uniprot_id}: {e}") from e
+            raise RuntimeError(
+                f"AlphaFold returned non-JSON for {uniprot_id}: {e}"
+            ) from e
 
         if not isinstance(records, list) or not records:
             raise ValueError(f"No AlphaFold DB predictions for {uniprot_id}")

--- a/backend/protzilla/importing/alphafold_protein_structure_load.py
+++ b/backend/protzilla/importing/alphafold_protein_structure_load.py
@@ -1,21 +1,28 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any
-
-import pandas as pd
-import requests
-from textwrap import wrap
-from CifFile import ReadCif
 import shutil
 import tempfile
+from pathlib import Path
+from textwrap import wrap
+from typing import Any
 
+import gemmi
+import pandas as pd
+import requests
 
 from backend.protzilla.constants import paths
 from backend.protzilla.constants.protzilla_logging import logger
 
 
 def _download_file(session: requests.Session, url: str, dest: Path) -> Path | None:
+    """
+    Download a file from a URL and save it to the specified destination path.
+
+    :param session: The requests session to use for the download
+    :param url: The URL of the file to download
+    :param dest: The destination path where the file should be saved
+    :return: The destination path if successful, None otherwise
+    """
     try:
         dest.parent.mkdir(parents=True, exist_ok=True)
         with session.get(url, stream=True, timeout=60) as r:
@@ -35,6 +42,15 @@ def _download_file(session: requests.Session, url: str, dest: Path) -> Path | No
 
 
 def to_fasta(seq: str, header: str = "protein_sequence", width: int = 60) -> str:
+    """
+    Convert a protein sequence to FASTA format.
+
+    :param seq: The protein sequence to convert
+    :param header: The header line for the FASTA record (default: "protein_sequence")
+    :param width: The maximum line width for sequence wrapping (default: 60)
+    :return: The sequence in FASTA format
+    :raises ValueError: If the sequence contains invalid characters or whitespace
+    """
     VALID_AA = set("ACDEFGHIKLMNPQRSTVWYBXZJUO*-")
     if not seq or any(c.isspace() for c in seq):
         raise ValueError("Sequence must be a single, whitespace-free string.")
@@ -45,7 +61,13 @@ def to_fasta(seq: str, header: str = "protein_sequence", width: int = 60) -> str
     return ">" + header + "\n" + "\n".join(wrap(seq, width)) + "\n"
 
 
-def fasta_to_dataframe(fasta_path: str):
+def fasta_to_dataframe(fasta_path: str) -> pd.DataFrame:
+    """
+    Parse a FASTA file and convert it to a DataFrame.
+
+    :param fasta_path: The path to the FASTA file
+    :return: A DataFrame with columns 'id', 'sequence', and 'length'
+    """
     records = []
     seq_id = None
     seq = []
@@ -58,11 +80,13 @@ def fasta_to_dataframe(fasta_path: str):
             if line.startswith(">"):
                 if seq_id is not None:
                     sequence = "".join(seq)
-                    records.append({
-                        "id": seq_id,
-                        "sequence": sequence,
-                        "length": len(sequence),
-                    })
+                    records.append(
+                        {
+                            "id": seq_id,
+                            "sequence": sequence,
+                            "length": len(sequence),
+                        }
+                    )
                 seq_id = line[1:].split()[0]
                 seq = []
             else:
@@ -70,28 +94,61 @@ def fasta_to_dataframe(fasta_path: str):
 
         if seq_id is not None:
             sequence = "".join(seq)
-            records.append({
-                "id": seq_id,
-                "sequence": sequence,
-                "length": len(sequence),
-            })
+            records.append(
+                {
+                    "id": seq_id,
+                    "sequence": sequence,
+                    "length": len(sequence),
+                }
+            )
 
     return pd.DataFrame(records)
 
 
-def cif_to_dataframe(cif_path):
-    cif = ReadCif(str(cif_path))
-    block = cif.first_block()
+def read_alphafold_mmcif(path: str) -> pd.DataFrame:
+    """
+    Parse an AlphaFold mmCIF (Macromolecular Crystallographic Information File) file.
 
-    df = pd.DataFrame({
-        "label": block["_atom_site_label"],
-        "element": block["_atom_site_type_symbol"],
-        "x": block["_atom_site_fract_x"],
-        "y": block["_atom_site_fract_y"],
-        "z": block["_atom_site_fract_z"],
-    })
+    :param path: The path to the mmCIF file
+    :return: A DataFrame containing the atom site information from the CIF file
+    :raises FileNotFoundError: If the file does not exist
+    :raises IsADirectoryError: If the path points to a directory instead of a file
+    :raises ValueError: If no CIF blocks are found in the file
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"File not found: {p}")
+    if p.is_dir():
+        raise IsADirectoryError(f"Expected a file path, got a directory: {p}")
 
-    return df
+    doc = gemmi.cif.read_file(str(p))
+    if len(doc) == 0:
+        raise ValueError(f"No CIF blocks found in file: {p}")
+
+    block = doc.sole_block()
+
+    cat_name = "_atom_site."
+    if cat_name not in block.get_mmcif_category_names():
+        return pd.DataFrame()
+
+    table = block.find_mmcif_category(cat_name)
+    if table is None:
+        return pd.DataFrame()
+
+    columns = list(table.tags)
+    nrows = len(table)
+    data = {}
+    for j, col in enumerate(columns):
+        col_values = []
+        for i in range(nrows):
+            row = table[i]
+            if j < len(row):
+                col_values.append(row[j])
+            else:
+                col_values.append(None)
+        data[col] = col_values
+
+    return pd.DataFrame(data)
 
 
 def _handle_alphafold_files(
@@ -103,15 +160,26 @@ def _handle_alphafold_files(
     acc: str,
     persist_upload: bool = False,
 ) -> tuple[
-    dict[str, str],
-    Path,
-    pd.DataFrame,
-    pd.DataFrame,
-    pd.DataFrame,
-    pd.DataFrame,
+    pd.DataFrame | None,
+    pd.DataFrame | None,
+    pd.DataFrame | None,
+    pd.DataFrame | None,
 ]:
     """
-    Either the files are persistently saved on disk and loaded into dataframes or only loaded into dataframes to be used only for the current run.
+    Download AlphaFold structure files and convert them to DataFrames.
+
+    Files can either be persistently saved to disk or only loaded into memory for the current run.
+    The function downloads CIF, PAE, and pLDDT files, converts them to DataFrames, and optionally
+    saves metadata to a CSV file.
+
+    :param session: The requests session to use for downloading files
+    :param files_urls: Dictionary containing URLs for CIF, PAE, and pLDDT files
+    :param uniprot: The UniProt ID of the protein
+    :param seq: The protein sequence
+    :param metadata_df: DataFrame containing AlphaFold metadata
+    :param acc: The accession number (used for directory naming)
+    :param persist_upload: If True, files are saved persistently; if False, only loaded into memory
+    :return: Tuple of (cif_df, pae_df, plddt_df, sequence_df) or None values for failed loads
     """
     cif_df = None
     pae_df = None
@@ -160,7 +228,14 @@ def _handle_alphafold_files(
                     downloaded[key] = str(saved)
                     try:
                         if key == "cifUrl":
-                            cif_df = cif_to_dataframe(saved)
+                            try:
+                                cif_df = read_alphafold_mmcif(str(saved))
+                            except Exception:
+                                logger.exception(
+                                    "Failed to load CIF into dataframe. Path=%s",
+                                    str(saved),
+                                )
+                                raise
                         elif key == "paeDocUrl":
                             pae_df = pd.read_json(saved)
                         elif key == "plddtDocUrl":
@@ -188,9 +263,22 @@ def _handle_alphafold_files(
     return cif_df, pae_df, plddt_df, sequence_df
 
 
-def fetch_alphafold_protein_structure(uniprot: str, persistUploads: bool,) -> dict[str, Any]:
-    url = f"https://alphafold.ebi.ac.uk/api/prediction/{uniprot}"
+def fetch_alphafold_protein_structure(
+    uniprot: str, persist_uploads: bool
+) -> dict[str, Any]:
+    """
+    Fetch AlphaFold protein structure data from the AlphaFold Database API.
 
+    Retrieves metadata and structure files (CIF, PAE, pLDDT) from the AlphaFold Database
+    for the given UniProt ID. Optionally persists the downloaded files to disk.
+
+    :param uniprot: The UniProt ID of the protein
+    :param persist_uploads: If True, files are saved persistently; if False, only loaded into memory
+    :return: A dictionary containing DataFrames for metadata, CIF, PAE, pLDDT, and sequence data
+    :raises RuntimeError: If the API request fails or returns invalid data
+    :raises ValueError: If no predictions are found for the given UniProt ID
+    """
+    url = f"https://alphafold.ebi.ac.uk/api/prediction/{uniprot}"
     with requests.Session() as session:
         try:
             resp = session.get(url, timeout=30)
@@ -227,8 +315,15 @@ def fetch_alphafold_protein_structure(uniprot: str, persistUploads: bool,) -> di
         metadata_df = pd.DataFrame([data])
         acc = data.get("uniprotAccession")
 
-        cif_df, pae_df, plddt_df, sequence_df = _handle_alphafold_files(session=session, files_urls=files_urls, uniprot=uniprot, seq=seq_tmp, metadata_df=metadata_df, acc=acc, persist_upload=persistUploads)
-        
+        cif_df, pae_df, plddt_df, sequence_df = _handle_alphafold_files(
+            session=session,
+            files_urls=files_urls,
+            uniprot=uniprot,
+            seq=seq_tmp,
+            metadata_df=metadata_df,
+            acc=acc,
+            persist_upload=persist_uploads,
+        )
 
         return {
             "metadata_df": metadata_df,

--- a/backend/protzilla/importing/alphafold_protein_structure_load.py
+++ b/backend/protzilla/importing/alphafold_protein_structure_load.py
@@ -26,11 +26,11 @@ def to_fasta(seq: str, header: str = "protein_sequence", width: int = 60) -> str
     :return: The sequence in FASTA format
     :raises ValueError: If the sequence contains invalid characters or whitespace
     """
-    VALID_AMINO_ACID = set("ACDEFGHIKLMNPQRSTVWYBXZJUO*-")
+    VALID_AMINO_ACIDS = set("ACDEFGHIKLMNPQRSTVWYBXZJUO*-")
     if not seq or any(c.isspace() for c in seq):
         raise ValueError("Sequence must be a single, whitespace-free string.")
     seq = seq.upper()
-    bad = set(seq) - VALID_AMINO_ACID
+    bad = set(seq) - VALID_AMINO_ACIDS
     if bad:
         raise ValueError(f"Invalid characters in sequence: {''.join(sorted(bad))}")
     joined = "\n".join(wrap(seq, width))
@@ -104,7 +104,7 @@ def handle_alphafold_files(
     :param metadata_df: DataFrame containing AlphaFold metadata
     :param acc: The accession number (used for directory naming)
     :param persist_uploads: If True, files are saved persistently; if False, only loaded into memory
-    :return: Tuple of (cif_df, pae_df, plddt_df, sequence_df) or None values for failed loads
+    :return: A dictionary containing DataFrames for metadata, CIF, PAE, pLDDT, and sequence data or None values for failed loads
     """
     cif_df = None
     pae_df = None

--- a/backend/protzilla/importing/alphafold_protein_structure_load.py
+++ b/backend/protzilla/importing/alphafold_protein_structure_load.py
@@ -64,40 +64,37 @@ def fetch_alphafold_protein_structure(uniprot: str) -> dict[str, Any]:
             ),
         }
 
+        files_urls: dict[str, Any] = {}
+
         for key in ("pdbUrl", "cifUrl", "paeDocUrl", "plddtDocUrl"):
             if isinstance(r.get(key), str) and r.get(key):
-                data[key] = r[key]
+                files_urls[key] = r[key]
 
         # prefer reading the existing AlphaFold metadata CSV into the dataframe
         meta_dir = paths.EXTERNAL_DATA_PATH / "alphafold"
         meta_dir.mkdir(parents=True, exist_ok=True)
         metadata_csv = meta_dir / "alphafold_metadata.csv"
 
-        new_row = pd.DataFrame([data])
+        alphafold_df = pd.DataFrame([data])
         try:
             if metadata_csv.exists():
                 existing = pd.read_csv(metadata_csv, dtype=str)
                 acc = data.get("uniprotAccession")
                 if acc and "uniprotAccession" in existing.columns:
                     existing = existing[existing["uniprotAccession"] != acc]
-                combined = pd.concat([existing, new_row], ignore_index=True)
-            else:
-                combined = new_row
+                combined = pd.concat([existing, alphafold_df], ignore_index=True)
 
             combined.to_csv(metadata_csv, index=False)
             logger.info("Wrote AlphaFold metadata to %s", metadata_csv)
-            alphafold_df = combined
         except Exception:
             logger.exception(
                 "Failed to write AlphaFold metadata CSV to %s", metadata_csv
             )
-            alphafold_df = new_row
-
         downloaded: dict[str, str] = {}
 
         target_dir = meta_dir / (data.get("uniprotAccession") or uniprot)
         for key in ("cifUrl", "pdbUrl", "paeDocUrl", "plddtDocUrl"):
-            urlval = data.get(key)
+            urlval = files_urls.get(key)
             if isinstance(urlval, str) and urlval:
                 fname = urlval.split("?")[0].rstrip("/").split("/")[-1]
                 dest = target_dir / fname

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -431,7 +431,7 @@ class AlphaFoldPredictionLoad(ImportingStep):
                     label="Protein ID",
                 ),
                 CheckboxField(
-                    name="persistUploads",
+                    name="persist_uploads",
                     label="Upload should be saved persistently across runs",
                     value=True,
                 ),

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -413,7 +413,11 @@ class AlphaFoldPredictionLoad(ImportingStep):
     method_description = "Loads the predicted structure of the protein with the given protein ID out of the AlphaFold DB."
 
     output_keys = [
-        "alphafold_df",
+        "metadata_df",
+        "cif_df",
+        "pae_df",
+        "plddt_df",
+        "sequence_df",
     ]
 
     plot_method = None

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -426,6 +426,11 @@ class AlphaFoldPredictionLoad(ImportingStep):
                     name="uniprot",
                     label="Protein ID",
                 ),
+                CheckboxField(
+                    name="persistUploads",
+                    label="Upload should be saved persistently across runs",
+                    value=True,
+                ),
             ],
         )
 

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -427,7 +427,7 @@ class AlphaFoldPredictionLoad(ImportingStep):
             label="AlphaFold DB Prediction Load",
             input_fields=[
                 TextField(
-                    name="uniprot",
+                    name="uniprot_id",
                     label="Protein ID",
                 ),
                 CheckboxField(

--- a/backend/protzilla/networking.py
+++ b/backend/protzilla/networking.py
@@ -1,0 +1,32 @@
+import requests
+from pathlib import Path
+from backend.protzilla.constants.protzilla_logging import logger
+
+
+def download_file_from_url(url: str, dest: Path) -> Path | None:
+    """
+    Download a file from a URL and save it to the specified destination path.
+
+    :param url: The URL of the file to download
+    :param dest: The destination path where the file should be saved
+    :return: The destination path if successful, None otherwise
+    """
+    with requests.Session() as session:
+
+        r = session.get(url, timeout=30)
+        r.raise_for_status()
+
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with open(dest, "wb") as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)
+        logger.info("Downloaded %s -> %s", url, dest)
+        return dest
+    except requests.RequestException:
+        logger.exception("Failed to download %s", url)
+        return None
+    except OSError:
+        logger.exception("Failed to write file %s", dest)
+        return None

--- a/backend/tests/protzilla/importing/test_alphafold_protein_structure_load.py
+++ b/backend/tests/protzilla/importing/test_alphafold_protein_structure_load.py
@@ -1,0 +1,167 @@
+import pandas as pd
+import pytest
+from pathlib import Path
+
+
+from backend.protzilla.importing.alphafold_protein_structure_load import (
+    fetch_alphafold_protein_structure,
+    to_fasta,
+    read_alphafold_mmcif,
+)
+import backend.protzilla.importing.alphafold_protein_structure_load as af
+
+
+def test_to_fasta_default_header_and_newline():
+    seq = "A" * 130
+    out = to_fasta(seq, "test_id", 60)
+
+    expected = (
+        ">alpha|test_id\n" + ("A" * 60) + "\n" + ("A" * 60) + "\n" + ("A" * 10) + "\n"
+    )
+    assert out == expected
+
+
+def test_to_fasta_invalid_characters():
+    with pytest.raises(ValueError, match=r"Invalid characters in sequence: 01@"):
+        to_fasta("AbbC@D1Eeff0")
+
+
+def test_to_fasta_whitespace():
+    with pytest.raises(
+        ValueError, match=r"Sequence must be a single, whitespace-free string."
+    ):
+        to_fasta(" ")
+
+
+def test_read_alphafold_mmcif_file_not_found(tmp_path):
+    missing = tmp_path / "unexisting.cif"
+    with pytest.raises(FileNotFoundError):
+        read_alphafold_mmcif(str(missing))
+
+
+def test_read_alphafold_mmcif_is_directory(tmp_path):
+    with pytest.raises(IsADirectoryError):
+        read_alphafold_mmcif(str(tmp_path))
+
+
+def test_read_alphafold_mmcif_empty(tmp_path):
+    cif = tmp_path / "empty.cif"
+    cif.write_text("")
+    with pytest.raises(ValueError, match="No CIF blocks found"):
+        read_alphafold_mmcif(str(cif))
+
+
+def test_read_alphafold_mmcif_atom_site_not_found(tmp_path):
+    cif = tmp_path / "no_atom_site.cif"
+    cif.write_text(
+        """
+data_test
+_entry.id test
+"""
+    )
+    df = read_alphafold_mmcif(str(cif))
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty
+
+
+def test_read_alphafold_mmcif_valid_atom_site(tmp_path):
+    cif = tmp_path / "atom_site.cif"
+    cif.write_text(
+        """
+data_test
+loop_
+_atom_site.id
+_atom_site.type_symbol
+_atom_site.Cartn_x
+N N 1.0
+CA C 2.0
+"""
+    )
+
+    df = read_alphafold_mmcif(str(cif))
+
+    assert isinstance(df, pd.DataFrame)
+    assert list(df.columns) == [
+        "_atom_site.id",
+        "_atom_site.type_symbol",
+        "_atom_site.Cartn_x",
+    ]
+    assert len(df) == 2
+    assert df["_atom_site.id"].tolist() == ["N", "CA"]
+    assert df["_atom_site.type_symbol"].tolist() == ["N", "C"]
+    assert df["_atom_site.Cartn_x"].tolist() == ["1.0", "2.0"]
+
+
+def test_fetch_alphafold_protein_structure_wrong_uniprot_id():
+    with pytest.raises(RuntimeError, match="AlphaFold request failed for NOPROTEIN"):
+        fetch_alphafold_protein_structure(uniprot="NOPROTEIN", persist_uploads=True)
+
+
+def test_fetch_alphafold_returned_keys(tmp_path, monkeypatch):
+    monkeypatch.setattr(af.paths, "EXTERNAL_DATA_PATH", tmp_path)
+
+    out = af.fetch_alphafold_protein_structure("Q8WP00", persist_uploads=True)
+    assert set(out.keys()) == {
+        "metadata_df",
+        "cif_df",
+        "pae_df",
+        "plddt_df",
+        "sequence_df",
+    }
+
+
+def test_fetch_alphafold_metadata(tmp_path, monkeypatch):
+    monkeypatch.setattr(af.paths, "EXTERNAL_DATA_PATH", tmp_path)
+    out = af.fetch_alphafold_protein_structure("Q8WP00", persist_uploads=True)
+
+    assert isinstance(out["metadata_df"], pd.DataFrame)
+    assert not out["metadata_df"].empty
+    assert out["metadata_df"].iloc[0]["uniprotAccession"] == "Q8WP00"
+    assert out["metadata_df"].iloc[0]["modelCreatedDate"] == "2025-08-01T00:00:00Z"
+    assert out["metadata_df"].iloc[0]["gene"] == "PRM1"
+    assert (
+        out["metadata_df"].iloc[0]["alphafold_version"]
+        == "AlphaFold Monomer v2.0 pipeline"
+    )
+
+
+def test_fetch_alphafold_files_exist(tmp_path, monkeypatch):
+    monkeypatch.setattr(af.paths, "EXTERNAL_DATA_PATH", tmp_path)
+    af.fetch_alphafold_protein_structure("Q8WP00", persist_uploads=True)
+
+    target_dir = tmp_path / "alphafold" / "Q8WP00"
+    assert target_dir.exists()
+    assert target_dir.is_dir()
+
+    fasta_path = target_dir / "Q8WP00.fasta"
+    assert fasta_path.exists()
+    assert fasta_path.stat().st_size > 0
+
+    cif_files = sorted(target_dir.glob("*.cif"))
+    json_files = sorted(target_dir.glob("*.json"))
+
+    # one mmCif file, confidence json and predicted aligned error
+    assert len(cif_files) == 1
+    assert len(json_files) == 2
+
+
+def test_fetch_alphafold_dfs_exist(tmp_path, monkeypatch):
+    monkeypatch.setattr(af.paths, "EXTERNAL_DATA_PATH", tmp_path)
+    out = af.fetch_alphafold_protein_structure("Q8WP00", persist_uploads=True)
+
+    cif_df = out["cif_df"]
+    assert isinstance(cif_df, pd.DataFrame)
+    assert not cif_df.empty
+    assert any(col.startswith("_atom_site.") for col in cif_df.columns)
+
+    pae_df = out["pae_df"]
+    assert isinstance(pae_df, pd.DataFrame)
+    assert not pae_df.empty
+
+    plddt_df = out["plddt_df"]
+    assert isinstance(plddt_df, pd.DataFrame)
+    assert not plddt_df.empty
+
+    seq_df = out["sequence_df"]
+    assert isinstance(seq_df, pd.DataFrame)
+    assert not seq_df.empty

--- a/backend/tests/protzilla/importing/test_alphafold_protein_structure_load.py
+++ b/backend/tests/protzilla/importing/test_alphafold_protein_structure_load.py
@@ -94,7 +94,7 @@ CA C 2.0
 
 def test_fetch_alphafold_protein_structure_wrong_uniprot_id():
     with pytest.raises(RuntimeError, match="AlphaFold request failed for NOPROTEIN"):
-        fetch_alphafold_protein_structure(uniprot="NOPROTEIN", persist_uploads=True)
+        fetch_alphafold_protein_structure(uniprot_id="NOPROTEIN", persist_uploads=True)
 
 
 def test_fetch_alphafold_returned_keys(tmp_path, monkeypatch):

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ plotly==6.4.0
 pre-commit==4.4.0
 git+https://git@github.com/hendraet/ptm-visualization.git@main#egg=protein_sequencing
 psutil==7.1.3
+PyCifRW==5.0.1
 pydeseq2==0.5.3
 pytest==9.0.1
 pytest-cov==7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ dash-bio==1.0.2
 debugpy==1.8.18
 Django==5.2.8
 django-cors-headers==4.9.0
+gemmi==0.6.6
 gseapy==1.1.10
 isort==7.0.0
 joblib==1.5.2
@@ -24,7 +25,6 @@ plotly==6.4.0
 pre-commit==4.4.0
 git+https://git@github.com/hendraet/ptm-visualization.git@main#egg=protein_sequencing
 psutil==7.1.3
-PyCifRW==5.0.1
 pydeseq2==0.5.3
 pytest==9.0.1
 pytest-cov==7.0.0


### PR DESCRIPTION
## Description
fixes #196
There now is an option for the user whether to save the data loaded from the alphafold db across runs or only for the current run. Also regardless of the choice, in both cases the data is also loaded into dataframes so we can work with them later down the line.

## Changes
Most important logic is in [alphafold_protein_structure_load.py](backend/protzilla/importing/alphafold_protein_structure_load.py). The option was also added in the forms. I added one library to parse the cif files.


## Testing
Start a new run. Load a specific protein and click the option to save it across runs. It should then be saved under user_data/external_data/alphafold. When uploading the same again, it should not create a new entry or folder. Under the Tables tab you should be able to find all the output dataframes. When not clicking the option to save it across runs, you should still be able to see these dataframes, however the data should not be saved under user_data anymore.


## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [x] At least one other developer reviewed and approved the changes
