### PR TITLE
 add non-technical user install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,17 @@
 PROTzilla is an open-source and browser-based tool for downstream proteomics MS analysis, enabling non-programmers to preprocess data, perform analyses, and generate publication-ready plots. The shareable, reproducible workflows and the integration of knowledge databases support automated analysis and transparent reporting in proteomics research.
 
 ## :gear: Deploy PROTzilla
+
+### Regular setup
+
+We have prepared guides for [Windows](./docs/Windows.md), [MacOS](./docs/MacOS.md) and [Linux](./docs/Linux.md).
+
+### Development (Docker)
+
 1. Clone the PROTzilla repository <br> `git clone https://github.com/cschlaffner/PROTzilla.git`
 2. Enter repository folder <br> `cd PROTzilla`
 
-### :whale: Using Docker (recommended)
-
-First, make sure you have [Docker](https://www.docker.com/) and Docker Compose installed. 
-
-#### Development
+Before running, make sure you have [Docker](https://www.docker.com/) and Docker Compose installed. 
 
 1. Run `docker compose up --build vite` (or `docker-compose up --build vite` on old versions) <br> You can optionally add `-d` to detatch protzilla from your shell
 2. (optional) If you want persistent user data storage, uncomment the volume specification in the `docker-compose.yml` and adjust for your system. Make sure to copy the repo contents in `/backend/user_data` over to your desired persistent directory first.
@@ -27,12 +30,7 @@ First, make sure you have [Docker](https://www.docker.com/) and Docker Compose i
     For other setups, `debugpy` is listening on its default port 5678
 
 
-#### Production
-
-1. Run `docker compose up --build prod` (again, if this fails but Compose is installed, use `docker-compose`)
-2. The server listens on [localhost](http://localhost:8000)
-
-### Windows native 
+### Windows native
 > [!NOTE]
 > We ensure native compatibility with Windows Server 2012. If you can run Docker on your system, please use Docker.
 

--- a/Windows.md
+++ b/Windows.md
@@ -1,0 +1,59 @@
+# Windows installation guide
+
+## :whale: Docker
+
+You need to have Docker installed in order to execute PROTzilla. On Windows, this means downloading [Docker Desktop](https://docs.docker.com/desktop/setup/install/windows-install/) and running it before executing the next steps.
+
+## Download PROTzilla
+
+You can either use `git` (if available) to clone the repository (this makes retrieving updates much easier), or download an archive of the current state of the codebase.
+
+### Using `git`
+
+#### Prerequisite: Installing `git`
+
+If you don't have `git` installed, you can download it from [here](https://git-scm.com/install/windows). Just follow the instructions of the setup wizard.
+
+#### Cloning the repository
+
+1. navigate to the directory you would like to download PROTzilla to in the file explorer
+2. Open a new command line by right-clicking into blank space while holding down shift and selecting "Open command window here"
+3. Enter `git clone https://github.com/cschlaffner/PROTzilla.git`
+
+After the last command has finished, you should see a new directory named "PROTzilla" in the file explorer.
+
+### Downloading the zip
+
+If you only wish to download the current state of the repository, you don't need to have `git` installed. You can just navigate to [the repo page](https://github.com/cschlaffner/PROTzilla) and click on the green "<> Code" button. Here, select "Download ZIP" from the bottom of the dropdown and unpack the archive to a location of your choosing.
+
+## Configuring PROTzilla
+
+If you'd like to tweak some settings, you can edit the [compose file](compose.yml). For instance, by default the workflow and run data isn't saved outside of the Docker container. You can still export/import them, but after stopping the service and removing the container, all user uploads would be gone.
+They can be persisted by editing this section (find the `prod` section of `services`, should be the first):
+
+```yaml
+    # volumes:
+    # Use this if you want to persistently store user data
+    # - '/home/www/.protzilla/user_data:./home/prot/zilla/backend/user_data'
+```
+
+Uncomment the relevant parts and set the directory at which to save the user data (for instance at `./backend/user_data`, which would be inside the repo directory) and insert it before the colon to look like this:
+
+```yaml
+    volumes:
+    # Use this if you want to persistently store user data
+    - './backend/user_data:./home/prot/zilla/backend/user_data'
+```
+
+This specifies that the local directory `./backend/user_data` should be mounted at `./home/prot/zilla/backend/user_data` inside the docker container (where the software expects them to be).
+
+## Running PROTzilla
+
+Before executing Docker commands on Windows, you need to start Docker Desktop (otherwise, Docker commands will fail).
+Afterwards, you can open a command shell in the PROTzilla directory (or use the one from the cloning step if you didn't close it and run `docker compose up -d prod`). This will prepare everything and start the service. Once the command has finished, you can navigate to [localhost:8000](http://localhost:8000) and use PROTzilla!
+You should also see the container in Docker Desktop, where you can access logs or attach to a shell inside the container.
+
+## Stopping PROTzilla
+
+If you're done with the service, you can either click on the stop symbol (:stop-button:) next to the PROTzilla service in Docker Desktop or run `docker compose down` from a command prompt in the code directory.
+Note that all runs will be gone, should you remove the container (the trash can button in Docker Desktop)

--- a/backend/main/settings.py
+++ b/backend/main/settings.py
@@ -45,7 +45,9 @@ if not os.path.exists(UPLOAD_PATH):
 SECRET_KEY = "django-insecure-^b(z4a%_42zo=feur29^g5sz9+7a(gcqq_l8vgkd$og36@+x5f"
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get("DEBUG", False)
+# should be changed for prod setup
+# but requires static files to be served by proper webserver
+DEBUG = True
 
 ALLOWED_HOSTS = ["0.0.0.0", "127.0.0.1", "localhost", "django"]
 

--- a/compose.yml
+++ b/compose.yml
@@ -4,8 +4,6 @@ services:
     build: .
     ports:
       - "8000:8000"
-    environment:
-      - "DEBUG=False"
 
     # volumes:
     # Use this if you want to persistently store user data
@@ -17,8 +15,6 @@ services:
     build:
       context: .
       dockerfile: "backend/Dockerfile.dev"
-    environment:
-      - "DEBUG=True"
     volumes:
       - "./backend:/home/prot/zilla/backend:Z" # :Z is required for SELinux and should be ignored everywhere else
     ports:

--- a/compose.yml
+++ b/compose.yml
@@ -9,9 +9,9 @@ services:
 
     # volumes:
     # Use this if you want to persistently store user data
-    # - '/home/www/.protzilla/user_data:./home/prot/zilla/backend/user_data'
+    # - '/home/www/.protzilla/user_data:./home/prot/zilla/backend/user_data:Z' # :Z is required for SELinux and should be ignored everywhere else
     # Use this for backend changes to reflect without rebuilding
-    # - "./backend:/home/prot/zilla/backend"
+    # - "./backend:/home/prot/zilla/backend:Z" # :Z is required for SELinux and should be ignored everywhere else
 
   django:
     build:
@@ -20,7 +20,7 @@ services:
     environment:
       - "DEBUG=True"
     volumes:
-      - "./backend:/home/prot/zilla/backend"
+      - "./backend:/home/prot/zilla/backend:Z" # :Z is required for SELinux and should be ignored everywhere else
     ports:
       - "5678:5678"
     networks:
@@ -33,7 +33,7 @@ services:
     environment:
       - VITE_API_URL=http://django
     volumes:
-      - "./frontend/src:/prot/zilla/frontend/src"
+      - "./frontend/src:/prot/zilla/frontend/src:Z" # :Z is required for SELinux and should be ignored everywhere else
       - "node_modules:/prot/zilla/frontend/node_modules"
       - ".pnpm-store:/prot/zilla/frontend/.pnpm-store"
     networks:
@@ -50,8 +50,8 @@ services:
     environment:
       - "BROWSER=none"
     volumes:
-      - "./frontend/src:/prot/zilla/frontend/src"
-      - "./frontend/.storybook:/prot/zilla/frontend/.storybook"
+      - "./frontend/src:/prot/zilla/frontend/src:Z" # :Z is required for SELinux and should be ignored everywhere else
+      - "./frontend/.storybook:/prot/zilla/frontend/.storybook:Z"
       - "node_modules:/prot/zilla/frontend/node_modules"
       - ".pnpm-store:/prot/zilla/frontend/.pnpm-store"
     entrypoint: ["pnpm", "run", "storybook", "--no-open"]

--- a/docs/Linux.md
+++ b/docs/Linux.md
@@ -1,8 +1,8 @@
-# Windows installation guide
+# Linux installation guide
 
 ## :whale: Docker
 
-You need to have Docker installed in order to execute PROTzilla. On Windows, this means downloading [Docker Desktop](https://docs.docker.com/desktop/setup/install/windows-install/) and running it before executing the next steps.
+You need to have Docker installed in order to execute PROTzilla. On Linux, you have the choice of downloading [Docker Desktop](https://docs.docker.com/desktop/setup/install/linux/) which comes with a GUI or just the [Docker Engine](https://docs.docker.com/engine/install/) CLI tool. Follow the installation steps before continuing here.
 
 ## Download PROTzilla
 
@@ -12,21 +12,20 @@ You can either use `git` (if available) to clone the repository (this makes retr
 
 #### Prerequisite: Installing `git`
 
-If you don't have `git` installed, you can download it from [here](https://git-scm.com/install/windows). Just follow the instructions of the setup wizard.
+Most non-minimal linux distros already have git installed. You can check if it's installed by running `git --version` in your terminal emulator. If it can't be found, follow the instructions [here](https://git-scm.com/install/linux)
 
 #### Cloning the repository
 
-1. navigate to the directory you would like to download PROTzilla to in the file explorer
-2. Open a new command line by right-clicking into blank space while holding down shift and selecting "Open command window here"
-3. Enter `git clone https://github.com/cschlaffner/PROTzilla.git`
+1. Open your terminal emulator and `cd` into your desired destination directory for PROTzilla (cloning will create a new directory)
+2. Enter `git clone https://github.com/cschlaffner/PROTzilla.git`
 
-After the last command has finished, you should see a new directory named "PROTzilla" in the file explorer.
+Voila! There should be a new directory named PROTzilla.
 
 ### Downloading the zip
 
 If you only wish to download the current state of the repository, you don't need to have `git` installed. You can just navigate to [the repo page](https://github.com/cschlaffner/PROTzilla) and click on the green "<> Code" button. Here, select "Download ZIP" from the bottom of the dropdown and unpack the archive to a location of your choosing.
 
-## Configuring PROTzilla
+## Configuring PROTzilla (optional)
 
 If you'd like to tweak some settings, you can edit the [compose file](compose.yml). For instance, by default the workflow and run data isn't saved outside of the Docker container. You can still export/import them, but after stopping the service and removing the container, all user uploads would be gone.
 They can be persisted by editing this section (find the `prod` section of `services`, should be the first):
@@ -49,11 +48,10 @@ This specifies that the local directory `./backend/user_data` should be mounted 
 
 ## Running PROTzilla
 
-Before executing Docker commands on Windows, you need to start Docker Desktop (otherwise, Docker commands will fail).
-Afterwards, you can open a command shell in the PROTzilla directory (or use the one from the cloning step if you didn't close it and run `docker compose up -d prod`). This will prepare everything and start the service. Once the command has finished, you can navigate to [localhost:8000](http://localhost:8000) and use PROTzilla!
-You should also see the container in Docker Desktop, where you can access logs or attach to a shell inside the container.
+Once you have completed the installation steps, you can open a command shell in the PROTzilla directory (or use the one from the cloning step if you didn't close it) and run `docker compose up -d prod`. This will prepare everything and start the service. Once the command has finished, you can navigate to [localhost:8000](http://localhost:8000) and use PROTzilla!
+Note that on Linux, Docker Desktop and Docker Engine use separate contexts by default, so you won't see containers started from the CLI in Docker Desktop in case you installed it. This is explained in the "Docker Desktop vs. Docker Engine: What's the difference?" section on the installation page.
 
 ## Stopping PROTzilla
 
-If you're done with the service, you can either click on the stop symbol (:stop-button:) next to the PROTzilla service in Docker Desktop or run `docker compose down` from a command prompt in the code directory.
+If you're done with the service, you can click on the stop symbol (:stop-button:) next to the PROTzilla service in Docker Desktop (if installed) or run `docker compose down` from a terminal emulator in the code directory.
 Note that all runs will be gone, should you remove the container (the trash can button in Docker Desktop)

--- a/docs/Linux.md
+++ b/docs/Linux.md
@@ -12,14 +12,14 @@ You can either use `git` (if available) to clone the repository (this makes retr
 
 #### Prerequisite: Installing `git`
 
-Most non-minimal linux distros already have git installed. You can check if it's installed by running `git --version` in your terminal emulator. If it can't be found, follow the instructions [here](https://git-scm.com/install/linux)
+Most non-minimal linux distros already have git installed. You can check if it's installed by running `git --version` in your command line. If it can't be found, follow the instructions [here](https://git-scm.com/install/linux)
 
 #### Cloning the repository
 
-1. Open your terminal emulator and `cd` into your desired destination directory for PROTzilla (cloning will create a new directory)
+1. Open your command line and `cd` into your desired destination directory for PROTzilla (cloning will create a new directory)
 2. Enter `git clone https://github.com/cschlaffner/PROTzilla.git`
 
-Voila! There should be a new directory named PROTzilla.
+Et voilà! There should be a new directory named PROTzilla.
 
 ### Downloading the zip
 
@@ -28,7 +28,7 @@ If you only wish to download the current state of the repository, you don't need
 ## Configuring PROTzilla (optional)
 
 If you'd like to tweak some settings, you can edit the [compose file](compose.yml). For instance, by default the workflow and run data isn't saved outside of the Docker container. You can still export/import them, but after stopping the service and removing the container, all user uploads would be gone.
-They can be persisted by editing this section (find the `prod` section of `services`, should be the first):
+They can be made persistent by editing this section (find the `prod` section of `services`, should be the first):
 
 ```yaml
     # volumes:
@@ -48,10 +48,10 @@ This specifies that the local directory `./backend/user_data` should be mounted 
 
 ## Running PROTzilla
 
-Once you have completed the installation steps, you can open a command shell in the PROTzilla directory (or use the one from the cloning step if you didn't close it) and run `docker compose up -d prod`. This will prepare everything and start the service. Once the command has finished, you can navigate to [localhost:8000](http://localhost:8000) and use PROTzilla!
+Once you have completed the installation steps, you can open a command line in the PROTzilla directory (or use the one from the cloning step if you didn't close it) and run `docker compose up -d prod`. This will prepare everything and start the service. Once the command has finished, you can navigate to [localhost:8000](http://localhost:8000) and use PROTzilla!
 Note that on Linux, Docker Desktop and Docker Engine use separate contexts by default, so you won't see containers started from the CLI in Docker Desktop in case you installed it. This is explained in the "Docker Desktop vs. Docker Engine: What's the difference?" section on the installation page.
 
 ## Stopping PROTzilla
 
-If you're done with the service, you can click on the stop symbol (:stop-button:) next to the PROTzilla service in Docker Desktop (if installed) or run `docker compose down` from a terminal emulator in the code directory.
+If you're done with the service, you can click on the stop symbol (:stop-button:) next to the PROTzilla service in Docker Desktop (if installed) or run `docker compose down` from a command line in the code directory.
 Note that all runs will be gone, should you remove the container (the trash can button in Docker Desktop)

--- a/docs/MacOS.md
+++ b/docs/MacOS.md
@@ -16,7 +16,7 @@ If you don't have `git` installed, you can find the instructions [here](https://
 
 #### Cloning the repository
 
-1. navigate to the directory you would like to download PROTzilla to in the Finder
+1. Navigate to the directory you would like to download PROTzilla to in the Finder
 2. Open a terminal by right-clicking the directory name while holding down control (compare [here](https://discussions.apple.com/thread/256112405?sortBy=rank)) and selecting "Open in Terminal here"
 3. Enter `git clone https://github.com/cschlaffner/PROTzilla.git`
 
@@ -29,7 +29,7 @@ If you only wish to download the current state of the repository, you don't need
 ## Configuring PROTzilla (optional)
 
 If you'd like to tweak some settings, you can edit the [compose file](compose.yml). For instance, by default the workflow and run data isn't saved outside of the Docker container. You can still export/import them, but after stopping the service and removing the container, all user uploads would be gone.
-They can be persisted by editing this section (find the `prod` section of `services`, should be the first):
+They can be made persistent by editing this section (find the `prod` section of `services`, should be the first):
 
 ```yaml
     # volumes:

--- a/docs/MacOS.md
+++ b/docs/MacOS.md
@@ -1,0 +1,59 @@
+# Mac installation guide
+
+## :whale: Docker
+
+You need to have Docker installed in order to execute PROTzilla. On MacOS, this means downloading [Docker Desktop](https://docs.docker.com/desktop/setup/install/mac-install/) and running it before executing the next steps.
+
+## Download PROTzilla
+
+You can either use `git` (if available) to clone the repository (this makes retrieving updates much easier), or download an archive of the current state of the codebase.
+
+### Using `git`
+
+#### Prerequisite: Installing `git`
+
+If you don't have `git` installed, you can find the instructions [here](https://git-scm.com/install/mac).
+
+#### Cloning the repository
+
+1. navigate to the directory you would like to download PROTzilla to in the Finder
+2. Open a terminal by right-clicking the directory name while holding down control (compare [here](https://discussions.apple.com/thread/256112405?sortBy=rank)) and selecting "Open in Terminal here"
+3. Enter `git clone https://github.com/cschlaffner/PROTzilla.git`
+
+After the last command has finished, you should see a new directory named "PROTzilla" in the Finder.
+
+### Downloading the zip
+
+If you only wish to download the current state of the repository, you don't need to have `git` installed. You can just navigate to [the repo page](https://github.com/cschlaffner/PROTzilla) and click on the green "<> Code" button. Here, select "Download ZIP" from the bottom of the dropdown and unpack the archive to a location of your choosing.
+
+## Configuring PROTzilla (optional)
+
+If you'd like to tweak some settings, you can edit the [compose file](compose.yml). For instance, by default the workflow and run data isn't saved outside of the Docker container. You can still export/import them, but after stopping the service and removing the container, all user uploads would be gone.
+They can be persisted by editing this section (find the `prod` section of `services`, should be the first):
+
+```yaml
+    # volumes:
+    # Use this if you want to persistently store user data
+    # - '/home/www/.protzilla/user_data:./home/prot/zilla/backend/user_data'
+```
+
+Uncomment the relevant parts and set the directory at which to save the user data (for instance at `./backend/user_data`, which would be inside the repo directory) and insert it before the colon to look like this:
+
+```yaml
+    volumes:
+    # Use this if you want to persistently store user data
+    - './backend/user_data:./home/prot/zilla/backend/user_data'
+```
+
+This specifies that the local directory `./backend/user_data` should be mounted at `./home/prot/zilla/backend/user_data` inside the docker container (where the software expects them to be).
+
+## Running PROTzilla
+
+Before executing Docker commands on Mac, you need to start Docker Desktop (otherwise, Docker commands will fail) (@mac users, is this true?).
+Afterwards, you can open the Terminal app in the PROTzilla directory (or use the one from the cloning step if you didn't close it) and run `docker compose up -d prod`. This will prepare everything and start the service. Once the command has finished, you can navigate to [localhost:8000](http://localhost:8000) and use PROTzilla!
+You should also see the container in Docker Desktop, where you can access logs or attach to a shell inside the container.
+
+## Stopping PROTzilla
+
+If you're done with the service, you can either click on the stop symbol (:stop-button:) next to the PROTzilla service in Docker Desktop or run `docker compose down` from a command prompt in the code directory.
+Note that all runs will be gone, should you remove the container (the trash can button in Docker Desktop)

--- a/docs/MacOS.md
+++ b/docs/MacOS.md
@@ -49,7 +49,7 @@ This specifies that the local directory `./backend/user_data` should be mounted 
 
 ## Running PROTzilla
 
-Before executing Docker commands on Mac, you need to start Docker Desktop (otherwise, Docker commands will fail) (@mac users, is this true?).
+Before executing Docker commands on Mac, you need to start Docker Desktop (otherwise, Docker commands will fail).
 Afterwards, you can open the Terminal app in the PROTzilla directory (or use the one from the cloning step if you didn't close it) and run `docker compose up -d prod`. This will prepare everything and start the service. Once the command has finished, you can navigate to [localhost:8000](http://localhost:8000) and use PROTzilla!
 You should also see the container in Docker Desktop, where you can access logs or attach to a shell inside the container.
 

--- a/docs/Windows.md
+++ b/docs/Windows.md
@@ -2,6 +2,9 @@
 
 ## :whale: Docker
 
+> [!NOTE]
+> Note: If you have WSL (Windows Subsystem for Linux) installed and prefer using that you can follow the [Linux guide](./Linux.md)
+
 You need to have Docker installed in order to execute PROTzilla. On Windows, this means downloading [Docker Desktop](https://docs.docker.com/desktop/setup/install/windows-install/) and running it before executing the next steps.
 
 ## Download PROTzilla
@@ -12,11 +15,11 @@ You can either use `git` (if available) to clone the repository (this makes retr
 
 #### Prerequisite: Installing `git`
 
-If you don't have `git` installed, you can download it from [here](https://git-scm.com/install/windows). Just follow the instructions of the setup wizard.
+If you don't have `git` installed, you can download it from [here](https://git-scm.com/install/windows). Just follow the instructions of the setup wizard.  
 
 #### Cloning the repository
 
-1. navigate to the directory you would like to download PROTzilla to in the file explorer
+1. Navigate to the directory you would like to download PROTzilla to in the file explorer
 2. Open a new command line by right-clicking into blank space while holding down shift and selecting "Open command window here"
 3. Enter `git clone https://github.com/cschlaffner/PROTzilla.git`
 
@@ -29,7 +32,7 @@ If you only wish to download the current state of the repository, you don't need
 ## Configuring PROTzilla (optional)
 
 If you'd like to tweak some settings, you can edit the [compose file](compose.yml). For instance, by default the workflow and run data isn't saved outside of the Docker container. You can still export/import them, but after stopping the service and removing the container, all user uploads would be gone.
-They can be persisted by editing this section (find the `prod` section of `services`, should be the first):
+They can be made persistent by editing this section (find the `prod` section of `services`, should be the first):
 
 ```yaml
     # volumes:

--- a/docs/Windows.md
+++ b/docs/Windows.md
@@ -1,0 +1,59 @@
+# Windows installation guide
+
+## :whale: Docker
+
+You need to have Docker installed in order to execute PROTzilla. On Windows, this means downloading [Docker Desktop](https://docs.docker.com/desktop/setup/install/windows-install/) and running it before executing the next steps.
+
+## Download PROTzilla
+
+You can either use `git` (if available) to clone the repository (this makes retrieving updates much easier), or download an archive of the current state of the codebase.
+
+### Using `git`
+
+#### Prerequisite: Installing `git`
+
+If you don't have `git` installed, you can download it from [here](https://git-scm.com/install/windows). Just follow the instructions of the setup wizard.
+
+#### Cloning the repository
+
+1. navigate to the directory you would like to download PROTzilla to in the file explorer
+2. Open a new command line by right-clicking into blank space while holding down shift and selecting "Open command window here"
+3. Enter `git clone https://github.com/cschlaffner/PROTzilla.git`
+
+After the last command has finished, you should see a new directory named "PROTzilla" in the file explorer.
+
+### Downloading the zip
+
+If you only wish to download the current state of the repository, you don't need to have `git` installed. You can just navigate to [the repo page](https://github.com/cschlaffner/PROTzilla) and click on the green "<> Code" button. Here, select "Download ZIP" from the bottom of the dropdown and unpack the archive to a location of your choosing.
+
+## Configuring PROTzilla (optional)
+
+If you'd like to tweak some settings, you can edit the [compose file](compose.yml). For instance, by default the workflow and run data isn't saved outside of the Docker container. You can still export/import them, but after stopping the service and removing the container, all user uploads would be gone.
+They can be persisted by editing this section (find the `prod` section of `services`, should be the first):
+
+```yaml
+    # volumes:
+    # Use this if you want to persistently store user data
+    # - '/home/www/.protzilla/user_data:./home/prot/zilla/backend/user_data'
+```
+
+Uncomment the relevant parts and set the directory at which to save the user data (for instance at `./backend/user_data`, which would be inside the repo directory) and insert it before the colon to look like this:
+
+```yaml
+    volumes:
+    # Use this if you want to persistently store user data
+    - './backend/user_data:./home/prot/zilla/backend/user_data'
+```
+
+This specifies that the local directory `./backend/user_data` should be mounted at `./home/prot/zilla/backend/user_data` inside the docker container (where the software expects them to be).
+
+## Running PROTzilla
+
+Before executing Docker commands on Windows, you need to start Docker Desktop (otherwise, Docker commands will fail).
+Afterwards, you can open a command shell in the PROTzilla directory (or use the one from the cloning step if you didn't close it) and run `docker compose up -d prod`. This will prepare everything and start the service. Once the command has finished, you can navigate to [localhost:8000](http://localhost:8000) and use PROTzilla!
+You should also see the container in Docker Desktop, where you can access logs or attach to a shell inside the container.
+
+## Stopping PROTzilla
+
+If you're done with the service, you can either click on the stop symbol (:stop-button:) next to the PROTzilla service in Docker Desktop or run `docker compose down` from a command prompt in the code directory.
+Note that all runs will be gone, should you remove the container (the trash can button in Docker Desktop)


### PR DESCRIPTION
## Description
fixes #188 

Adds installation steps for the prod service on Windows, Mac and Linux.

## Changes

- `docs/*`: new directory with the guides
- `README.md`: point to new guides
- `compose.yml`: added a flag to the bind mount that SELinux users (me and Joris) need for them to work. Shouldn't break anything for anyone else.


## Testing

maybe try to follow the procedure once

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
