### PR TITLE
Multiple organism id input for crosslinking import 

### DIFF
--- a/backend/protzilla/importing/crosslinking_import.py
+++ b/backend/protzilla/importing/crosslinking_import.py
@@ -287,12 +287,10 @@ def uniprot_lookup(
     :rtype: None
     """
     if mode == ProteinDesignationLookupMode.id_to_gene_name.value:
-        error = ProteinLookupError.NO_GENE_NAME_FOUND.value
         field_of_existing_data = "accession"
         extra_query = None
         extra_fields = None
     elif mode == ProteinDesignationLookupMode.gene_name_to_id.value:
-        error = ProteinLookupError.NO_PROTEIN_ID_FOUND.value
         field_of_existing_data = "gene_exact"
         extra_query = f"organism_id:{organism_id} AND reviewed:true"
         extra_fields = "gene_names"
@@ -315,10 +313,6 @@ def uniprot_lookup(
         process_uniprot_response(
             response=response, results=results, input_data=batch, mode=mode
         )
-
-    for data in input_data:
-        if data not in results:
-            results[data] = (False, None, error)
 
 
 def get_gene_name_from_protein_ids(
@@ -368,19 +362,27 @@ def get_gene_name_from_protein_ids(
         organism_id=None,
     )
 
+    for protein_id in valid_ids_without_isoform:
+        if protein_id not in results:
+            results[protein_id] = (
+                False,
+                None,
+                ProteinLookupError.NO_GENE_NAME_FOUND.value,
+            )
+
     return results
 
 
 def get_protein_ids_from_gene_name(
-    gene_names: set[str], organism_id: str
+    gene_names: set[str], organism_ids: list[str]
 ) -> dict[str, tuple[bool, Optional[str], Optional[str]]]:
     """
     Retrieve UniProt protein IDs for a given set of human gene names as a batch query.
 
     :param gene_names: Set of gene symbols to look up (e.g., {"RAD50", "MRE11"})
     :type gene_names: set[str]
-    :param organism_id: Organism identifier for filtering UniProt queries (e.g., "9606" for human)
-    :type organism_id: str
+    :param organism_ids: list of organism identifiers for filtering UniProt queries (e.g., "9606" for human)
+    :type organism_ids: list[str]
 
     :return: Dictionary mapping each gene name to a tuple of (success, protein_id, error)
     :rtype: dict[str, tuple[bool, str | None, str | None]]
@@ -399,12 +401,30 @@ def get_protein_ids_from_gene_name(
     if not valid_gene_names:
         return results
 
-    uniprot_lookup(
-        input_data=valid_gene_names,
-        mode=ProteinDesignationLookupMode.gene_name_to_id.value,
-        results=results,
-        organism_id=organism_id,
-    )
+    remaining_gene_names = set(valid_gene_names)
+    for single_organism_id in organism_ids:
+
+        if not remaining_gene_names:
+            continue
+
+        uniprot_lookup(
+            input_data=remaining_gene_names,
+            mode=ProteinDesignationLookupMode.gene_name_to_id.value,
+            results=results,
+            organism_id=single_organism_id,
+        )
+
+        for gene_name in list(remaining_gene_names):
+            if gene_name in results:
+                remaining_gene_names.discard(gene_name)
+
+    for gene_name in valid_gene_names:
+        if gene_name not in results:
+            results[gene_name] = (
+                False,
+                None,
+                ProteinLookupError.NO_GENE_NAME_FOUND.value,
+            )
 
     return results
 
@@ -580,7 +600,7 @@ def read_ProteomeDiscoverer_XlinkX_file(
 
 
 def read_csm_file(
-    file_path: Path, organism_id: str
+    file_path: Path, organism_ids: list[str]
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """
     Read and process a CSM CSV file:
@@ -593,8 +613,8 @@ def read_csm_file(
 
     :param file_path: Path to the CSM CSV file
     :type file_path: pathlib.Path
-    :param organism_id: Organism identifier used for UniProt lookups (e.g., "9606" for human)
-    :type organism_id: str
+    :param organism_ids: list of organism identifiers used for UniProt lookups (e.g., "9606" for human)
+    :type organism_id: list[str]
 
     :return: Tuple of DataFrames containing rows with successfully mapped protein IDs
              and rows where lookup failed
@@ -609,14 +629,14 @@ def read_csm_file(
 
     df["Is_intra_crosslink"] = df["Protein1"].eq(df["Protein2"])
 
-    uniprot_lookup_function_with_organism_id = partial(
-        get_protein_ids_from_gene_name, organism_id=organism_id
+    uniprot_lookup_function_with_organism_ids = partial(
+        get_protein_ids_from_gene_name, organism_ids=organism_ids
     )
     good_df, failed_df = get_missing_protein_designation(
         df=df,
         existing_column="Protein",
         missing_column="Protein_id",
-        uniprot_lookup_function=uniprot_lookup_function_with_organism_id,
+        uniprot_lookup_function=uniprot_lookup_function_with_organism_ids,
     )
 
     return good_df, failed_df
@@ -643,35 +663,52 @@ def normalize_crosslinking_df(df: pd.DataFrame) -> pd.DataFrame:
     return df.loc[:, columns_in_crosslinking_df]
 
 
-def process_organism_id_from_text_field(organism_id: str) -> tuple[bool, Optional[str]]:
+def process_organism_id_from_text_field(
+    organism_ids: str,
+) -> tuple[bool, Optional[list[str]], Optional[list[str]]]:
     """
-    Retrieve the scientific name of an organism from its NCBI Taxonomy ID.
+    Validates a comma-separated string of NCBI Taxonomy IDs.
+    Returns False immediately if any ID is invalid.
+    Otherwise returns True, the list of cleaned IDs, and the corresponding scientific names.
 
-    The function:
-    1. Cleans the input organism ID (removes spaces).
-    2. Queries the NCBI Entrez E-utilities esummary endpoint.
-    3. Returns a tuple indicating whether the lookup succeeded and the scientific name.
+    param organism_ids: Comma-separated string of NCBI Taxonomy IDs (e.g., "9606,10090,10116")
+    :type organism_ids: str
 
-    :param organism_id: NCBI Taxonomy ID as a string (may contain spaces)
-    :type organism_id: str
-
-    :return: Tuple indicating success and the scientific name
-    :rtype: tuple[bool, str | None]
-
-    :returns success: True if the organism ID was found and the scientific name retrieved
-    :returns name: Scientific name of the organism if found, else None
+    :return: A tuple containing:
+        - success (bool): True if all IDs are valid, False if any ID is invalid
+        - ids (list[str] | None): List of cleaned IDs in input order if successful, None if failed or the cause of the fail
+        - names (list[str] | None): List of scientific names corresponding to IDs if successful, None if failed
     """
-    cleaned_organism_id = organism_id.strip().replace(" ", "")
-    url = f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=taxonomy&id={cleaned_organism_id}&retmode=json"
-    response = requests.get(url)
-    if response.status_code != 200:
-        return False, None
-    data = response.json()
-    output_ids = data.get("result", {})
-    if cleaned_organism_id not in output_ids:
-        return False, None
-    name = output_ids[cleaned_organism_id].get("scientificname")
-    return True, name
+    organism_ids_list: list[str] = [
+        id.strip() for id in organism_ids.split(",") if id.strip()
+    ]
+    if not organism_ids_list:
+        return False, None, None
+
+    organism_ids_for_request = ",".join(organism_ids_list)
+    url = f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=taxonomy&id={organism_ids_for_request}&retmode=json"
+    try:
+        response = requests.get(url, timeout=15)
+        if response.status_code != 200:
+            return False, None, None
+        data = response.json()
+    except Exception:
+        return False, None, None
+
+    result = data.get("result", {})
+    valid_organism_ids = result.get("uids", [])
+    organism_names = []
+
+    for id in organism_ids_list:
+        if id not in valid_organism_ids:
+            # Abort at the first invalid id
+            return False, id, None
+        name = result[id].get("scientificname")
+        if not name:
+            return False, id, None
+        organism_names.append(name)
+
+    return True, organism_ids_list, organism_names
 
 
 def aggregate_failed_proteins_for_display(failed_df: pd.DataFrame) -> str:
@@ -709,16 +746,19 @@ def aggregate_failed_proteins_for_display(failed_df: pd.DataFrame) -> str:
     return "\n".join(sorted(protein_with_error_set))
 
 
-def crosslinking_import(file_path: Path, organism_id: str) -> dict:
+def crosslinking_import(file_path: Path, organism_ids: str) -> dict:
     file_type = file_path.suffix
     try:
-        scientific_organism_name = None
+        scientific_organism_names: list[str] = None
         if file_type == ".csv":
-            success, scientific_organism_name = process_organism_id_from_text_field(
-                organism_id
+            success, organism_ids_list, scientific_organism_names = (
+                process_organism_id_from_text_field(organism_ids)
             )
             if not success:
-                msg = f"Unsupported organism id: {organism_id}. Please provide a valid taxonomy id."
+                if organism_ids_list:
+                    msg = f"Unsupported organism id: {organism_ids_list}. Please provide all valid taxonomy ids."
+                else:
+                    msg = f"An error occurred while reading the organism ids. Please provide all valid taxonomy ids, separated by a comma."
                 return dict(
                     messages=[
                         dict(
@@ -727,7 +767,7 @@ def crosslinking_import(file_path: Path, organism_id: str) -> dict:
                         )
                     ]
                 )
-            good_df, failed_df = read_csm_file(file_path, organism_id)
+            good_df, failed_df = read_csm_file(file_path, organism_ids_list)
         elif file_type == ".xlsx":
             good_df, failed_df = read_ProteomeDiscoverer_XlinkX_file(file_path)
         else:
@@ -746,7 +786,8 @@ def crosslinking_import(file_path: Path, organism_id: str) -> dict:
 
     def base_message():
         if file_type == ".csv":
-            return f"{len(good_df)} cross-links for the {scientific_organism_name} organism"
+            organism_names_string = ", ".join(scientific_organism_names)
+            return f"{len(good_df)} cross-links for the {organism_names_string} organism(s)"
         return f"{len(good_df)} cross-links"
 
     if good_df.empty:

--- a/backend/protzilla/importing/crosslinking_import.py
+++ b/backend/protzilla/importing/crosslinking_import.py
@@ -765,7 +765,7 @@ def error_output(msg, trace: str | None = None) -> dict:
 
 
 def crosslinking_import(file_path: Path, organism_ids: str) -> dict:
-    file_type = file_path.suffix
+    file_type = file_path.suffix.lower()
     try:
         scientific_organism_names: list[str] = None
         if file_type == ".csv":

--- a/backend/protzilla/importing/crosslinking_import.py
+++ b/backend/protzilla/importing/crosslinking_import.py
@@ -712,7 +712,7 @@ def process_organism_id_from_text_field(
             return False, id, None, "MISSING_SCIENTIFIC_NAME"
         organism_names.append(name)
 
-    return True, organism_ids_list, organism_names, None 
+    return True, organism_ids_list, organism_names, None
 
 
 def aggregate_failed_proteins_for_display(failed_df: pd.DataFrame) -> str:

--- a/backend/protzilla/importing/crosslinking_import.py
+++ b/backend/protzilla/importing/crosslinking_import.py
@@ -665,7 +665,7 @@ def normalize_crosslinking_df(df: pd.DataFrame) -> pd.DataFrame:
 
 def process_organism_id_from_text_field(
     organism_ids: str,
-) -> tuple[bool, Optional[list[str]], Optional[list[str]]]:
+) -> tuple[bool, Optional[list[str]], Optional[list[str]], Optional[str]]:
     """
     Validates a comma-separated string of NCBI Taxonomy IDs.
     Returns False immediately if any ID is invalid.
@@ -683,32 +683,36 @@ def process_organism_id_from_text_field(
         id.strip() for id in organism_ids.split(",") if id.strip()
     ]
     if not organism_ids_list:
-        return False, None, None
+        return False, None, None, "EMPTY_INPUT"
 
     organism_ids_for_request = ",".join(organism_ids_list)
     url = f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=taxonomy&id={organism_ids_for_request}&retmode=json"
     try:
         response = requests.get(url, timeout=15)
         if response.status_code != 200:
-            return False, None, None
+            return False, None, None, "NCBI_TAXONOMY_REQUEST_FAILED"
         data = response.json()
+    except requests.Timeout:
+        return False, None, None, "NCBI_TAXONOMY_TIMEOUT"
     except Exception:
-        return False, None, None
+        return False, None, None, "NCBI_TAXONOMY_SERVICE_UNAVAILABLE"
 
     result = data.get("result", {})
+    if not result or "uids" not in result:
+        return False, None, None, "NCBI_TAXONOMY_RESPONSE_INVALID"
     valid_organism_ids = result.get("uids", [])
     organism_names = []
 
     for id in organism_ids_list:
         if id not in valid_organism_ids:
             # Abort at the first invalid id
-            return False, id, None
+            return False, id, None, "ORGANISM_ID_NOT_FOUND"
         name = result[id].get("scientificname")
         if not name:
-            return False, id, None
+            return False, id, None, "MISSING_SCIENTIFIC_NAME"
         organism_names.append(name)
 
-    return True, organism_ids_list, organism_names
+    return True, organism_ids_list, organism_names, None 
 
 
 def aggregate_failed_proteins_for_display(failed_df: pd.DataFrame) -> str:
@@ -746,27 +750,34 @@ def aggregate_failed_proteins_for_display(failed_df: pd.DataFrame) -> str:
     return "\n".join(sorted(protein_with_error_set))
 
 
+def error_output(msg, trace: str | None = None) -> dict:
+    return dict(
+        crosslinking_df=pd.DataFrame(),
+        imported_rows_with_errors_df=pd.DataFrame(),
+        messages=[
+            dict(
+                level=logging.ERROR,
+                msg=msg,
+                trace=trace,
+            )
+        ],
+    )
+
+
 def crosslinking_import(file_path: Path, organism_ids: str) -> dict:
     file_type = file_path.suffix
     try:
         scientific_organism_names: list[str] = None
         if file_type == ".csv":
-            success, organism_ids_list, scientific_organism_names = (
+            success, organism_ids_list, scientific_organism_names, error = (
                 process_organism_id_from_text_field(organism_ids)
             )
             if not success:
                 if organism_ids_list:
-                    msg = f"Unsupported organism id: {organism_ids_list}. Please provide all valid taxonomy ids."
+                    msg = f"Unsupported organism id: {organism_ids_list}. \nOrganism id validation failed with error: {error}. \nPlease provide all valid taxonomy ids."
                 else:
-                    msg = f"An error occurred while reading the organism ids. Please provide all valid taxonomy ids, separated by a comma."
-                return dict(
-                    messages=[
-                        dict(
-                            level=logging.ERROR,
-                            msg=msg,
-                        )
-                    ]
-                )
+                    msg = f"An error occurred while reading the organism ids: {error}. \nPlease provide all valid taxonomy ids, separated by a comma."
+                return error_output(msg)
             good_df, failed_df = read_csm_file(file_path, organism_ids_list)
         elif file_type == ".xlsx":
             good_df, failed_df = read_ProteomeDiscoverer_XlinkX_file(file_path)
@@ -774,15 +785,7 @@ def crosslinking_import(file_path: Path, organism_ids: str) -> dict:
             raise ValueError(f"Unsupported file type: {file_path.suffix}")
     except Exception as e:
         msg = f"An error occurred while reading the file: {e.__class__.__name__} {e}. Please provide a valid cross linking file."
-        return dict(
-            messages=[
-                dict(
-                    level=logging.ERROR,
-                    msg=msg,
-                    trace=format_trace(traceback.format_exception(e)),
-                )
-            ]
-        )
+        return error_output(msg, trace=format_trace(traceback.format_exception(e)))
 
     def base_message():
         if file_type == ".csv":

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -463,7 +463,9 @@ class CrosslinkingImport(ImportingStep):
                     label="Organism IDs \n(only required when importing a CSM file)",
                     value="",
                 ),
-                InfoField(label="Please list them in the order in which they should be applied, separated by a comma \n e.g.: 9606, 10090, 10116"),
+                InfoField(
+                    label="Please list them in the order in which they should be applied, separated by a comma \n e.g.: 9606, 10090, 10116"
+                ),
             ],
         )
 

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -459,9 +459,11 @@ class CrosslinkingImport(ImportingStep):
                     value=None,
                 ),
                 TextField(
-                    name="organism_id",
-                    label="Organism ID",
+                    name="organism_ids",
+                    label="Organism IDs \n(please list them in the order in which they should be applied, separated by a comma)",
+                    value="",
                 ),
+                InfoField(label="e.g.: 9606, 10090, 10116"),
             ],
         )
 

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -460,10 +460,10 @@ class CrosslinkingImport(ImportingStep):
                 ),
                 TextField(
                     name="organism_ids",
-                    label="Organism IDs \n(please list them in the order in which they should be applied, separated by a comma)",
+                    label="Organism IDs \n(only required when importing a CSM file)",
                     value="",
                 ),
-                InfoField(label="e.g.: 9606, 10090, 10116"),
+                InfoField(label="Please list them in the order in which they should be applied, separated by a comma \n e.g.: 9606, 10090, 10116"),
             ],
         )
 

--- a/backend/tests/protzilla/importing/test_crosslinking_import.py
+++ b/backend/tests/protzilla/importing/test_crosslinking_import.py
@@ -52,7 +52,7 @@ def test_validate_data_before_lookup():
 
 
 def test_validate_data_before_lookup_empty():
-    valid, results = validate_data_before_lookup(set(), lambda x: True, "ERR")
+    valid, results = validate_data_before_lookup(set(), lambda x: True, "ERROR")
     assert valid == set()
     assert results == {}
 
@@ -124,7 +124,7 @@ def test_uniprot_lookup_successful_request_but_no_results(monkeypatch):
         results=results,
     )
 
-    assert results["P1"] == (False, None, "NO_GENE_NAME_FOUND")
+    assert results == {}
 
 
 def _minimal_valid_crosslinking_df():
@@ -181,6 +181,49 @@ def test_get_missing_protein_designation():
     assert failed_df.empty
 
 
+@pytest.mark.parametrize(
+    "input_string, mock_result, expected",
+    [
+        (
+            "9606,10090",
+            {
+                "uids": ["9606", "10090"],
+                "9606": {"scientificname": "Homo sapiens"},
+                "10090": {"scientificname": "Mus musculus"},
+            },
+            (True, ["9606", "10090"], ["Homo sapiens", "Mus musculus"]),
+        ),
+        (
+            "9606,9999",
+            {
+                "uids": ["9606"],
+                "9606": {"scientificname": "Homo sapiens"},
+            },
+            (False, "9999", None),
+        ),
+    ],
+)
+def test_process_organism_id_from_text_field(
+    monkeypatch, input_string, mock_result, expected
+):
+    from protzilla.importing.crosslinking_import import (
+        process_organism_id_from_text_field,
+    )
+
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"result": mock_result}
+
+    monkeypatch.setattr(
+        "protzilla.importing.crosslinking_import.requests.get",
+        lambda *args, **kwargs: mock_response,
+    )
+
+    result = process_organism_id_from_text_field(input_string)
+
+    assert result == expected
+
+
 def test_aggregate_failed_proteins_for_display():
     df = pd.DataFrame(
         {
@@ -216,7 +259,7 @@ def test_crosslinking_import_csv(tmp_path):
             "MRE11": (True, "Q67890", None),
         },
     ):
-        result = crosslinking_import(csv_file, organism_id="9606")
+        result = crosslinking_import(csv_file, organism_ids="9606")
 
     assert "crosslinking_df" in result
     assert not result["crosslinking_df"].empty
@@ -245,13 +288,13 @@ def test_crosslinking_import_xlsx(monkeypatch, tmp_path):
         lambda ids: {i: (True, f"G{i}", None) for i in ids},
     )
 
-    result = crosslinking_import(xlsx, organism_id="9606")
+    result = crosslinking_import(xlsx, organism_ids="9606")
     assert "crosslinking_df" in result
 
 
 def test_crosslinking_import_invalid_file(tmp_path):
     bad_file = tmp_path / "test.txt"
     bad_file.write_text("something invalid")
-    result = crosslinking_import(bad_file, organism_id="9606")
+    result = crosslinking_import(bad_file, organism_ids="9606")
     assert "messages" in result
     assert any("Unsupported file type" in m["msg"] for m in result["messages"])

--- a/backend/tests/protzilla/importing/test_crosslinking_import.py
+++ b/backend/tests/protzilla/importing/test_crosslinking_import.py
@@ -191,7 +191,7 @@ def test_get_missing_protein_designation():
                 "9606": {"scientificname": "Homo sapiens"},
                 "10090": {"scientificname": "Mus musculus"},
             },
-            (True, ["9606", "10090"], ["Homo sapiens", "Mus musculus"]),
+            (True, ["9606", "10090"], ["Homo sapiens", "Mus musculus"], None),
         ),
         (
             "9606,9999",
@@ -199,7 +199,7 @@ def test_get_missing_protein_designation():
                 "uids": ["9606"],
                 "9606": {"scientificname": "Homo sapiens"},
             },
-            (False, "9999", None),
+            (False, "9999", None, "ORGANISM_ID_NOT_FOUND"),
         ),
     ],
 )


### PR DESCRIPTION
## Description
fixes #235 
Changes follow exactly what is described in this issue. 

## Changes
backend/protzilla/methods/importing.py ➞ some changes to the organism id input field (mostly added descriptions) 
backend/protzilla/importing/crosslinking_inport.py ➞ changes to the logic so that a list of organism ids can be processed 


## Testing
Enter several different lists of organism ids and try to import both file types with those. Try some intentionally wrong inputs and check if the error messages you see correspond to what you did wrong.

Maybe try to import a csm file with the organism id 9606 and/ or 10090 and see what difference that makes in the failed proteins, that are shown in the warning after the import. 

(The acceptance criteria in the issue #235 might also give some ideas on what to test) 

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [x] At least one other developer reviewed and approved the changes
