### PR TITLE
220 refactor alphafold input for crosslinking validation

### DIFF
--- a/backend/protzilla/data_analysis/crosslinking_validation.py
+++ b/backend/protzilla/data_analysis/crosslinking_validation.py
@@ -124,18 +124,18 @@ def get_position_of_amino_acid_crosslinker_bound_to(
 
 
 def get_distance_between_crosslinker_connected_amino_acids_in_alphafold(
-    fasta_df: pd.DataFrame, cif_df: pd.DataFrame, crosslink: pd.Series
+    amino_acid_sequence_df: pd.DataFrame, cif_df: pd.DataFrame, crosslink: pd.Series
 ) -> float:
     """
     Calculates the distance in Ångström between two amino acid residues connected
     by a cross-linker using a predicted protein structure (e.g. from AlphaFold).
 
-    :param fasta_df: DataFrame containing the protein sequence
+    :param amino_acid_sequence_df: DataFrame containing the protein sequence
     :param cif_df: DataFrame containing CIF information (predicted coordinates of all the protein's atoms)
     :param crosslink: Series describing a cross-link, including cross-linker positions
     :return: the distance between the cross-linked amino acids in Ångström
     """
-    protein_sequence = fasta_df.at[0, "Protein Sequence"]
+    protein_sequence = amino_acid_sequence_df.at[0, "Protein Sequence"]
     amino_acid_position_crosslinker1_is_bound_to = (
         get_position_of_amino_acid_crosslinker_bound_to(
             protein_sequence=protein_sequence,
@@ -164,6 +164,8 @@ def validate_with_angstrom_deviation(
     crosslinking_df: pd.DataFrame,
     protein_to_validate: str,
     crosslinker_information: dict[str, list[float]],
+    cif_df: pd.DataFrame,
+    amino_acid_sequence_df: pd.DataFrame,
 ) -> dict:
     """
     Validates cross-links by comparing the cross-linker lengths with the distances between the linked
@@ -177,18 +179,14 @@ def validate_with_angstrom_deviation(
                    - length_of_<Crosslinker>: float
                    - lower_accepted_deviation_for_<Crosslinker>: float
                    - upper_accepted_deviation_for_<Crosslinker>: float
+    :param cif_df: DataFrame containing CIF information (predicted coordinates of all the protein's atoms)
+    :param amino_acid_sequence_df: DataFrame containing the protein sequence
     :return: dict (crosslinking_df_result, messages), crosslinking_df_result contains the relevant rows (rows of intra-crosslinks within the
     protein to validate) of crosslinking_df and two more colums containing the distances in AlphaFold and wheter the crosslink matches the
     AlphaFold data or not
     :raises KeyError: If a required crosslinker field is missing in crosslinker_information.
     :raises ValueError: If peptide sequences cannot be matched to the protein sequence.
     """
-    alphafold_data = fetch_alphafold_protein_structure(
-        uniprot_id=protein_to_validate, persist_uploads=False
-    )
-    cif_df = alphafold_data["cif_df"]
-    fasta_df = alphafold_data["sequence_df"]
-
     all_crosslinks_df = crosslinking_df.copy()
 
     # we are only interested in intra-crosslinks of the protein we want to validate
@@ -199,7 +197,7 @@ def validate_with_angstrom_deviation(
 
     def check_crosslink(crosslink: pd.Series) -> pd.Series:
         distance = get_distance_between_crosslinker_connected_amino_acids_in_alphafold(
-            fasta_df, cif_df, crosslink
+            amino_acid_sequence_df, cif_df, crosslink
         )
         try:
             (
@@ -243,6 +241,8 @@ def bar_plot_of_valid_crosslinks(
     crosslinking_df: pd.DataFrame,
     protein_to_validate: str,
     crosslinker_information: dict[str, list[float]],
+    cif_df: pd.DataFrame,
+    amino_acid_sequence_df: pd.DataFrame,
 ) -> list[Figure]:
     """
     Creates a bar plot summarizing the number of valid and invalid cross-links
@@ -255,12 +255,18 @@ def bar_plot_of_valid_crosslinks(
                    - length_of_<Crosslinker>: float
                    - lower_accepted_deviation_for_<Crosslinker>: float
                    - upper_accepted_deviation_for_<Crosslinker>: float
+    :param cif_df: DataFrame containing CIF information (predicted coordinates of all the protein's atoms)
+    :param amino_acid_sequence_df: DataFrame containing the protein sequence
     :return: List containing a single bar plot object representing counts of
              valid and invalid cross-links.
     :raises KeyError: If a required crosslinker field is missing in crosslinker_information.
     """
     validated_df = validate_with_angstrom_deviation(
-        crosslinking_df, protein_to_validate, crosslinker_information
+        crosslinking_df,
+        protein_to_validate,
+        crosslinker_information,
+        cif_df,
+        amino_acid_sequence_df,
     )["crosslinking_result_df"]
 
     evaluated = validated_df["valid_crosslink"].dropna()

--- a/backend/protzilla/importing/alphafold_protein_structure_load.py
+++ b/backend/protzilla/importing/alphafold_protein_structure_load.py
@@ -134,7 +134,7 @@ def handle_alphafold_files(
     cif_df = None
     pae_df = None
     plddt_df = None
-    sequence_df = None
+    amino_acid_sequence_df = None
     messages = []
 
     target_dir = paths.ALPHAFOLD_PATH / uniprot
@@ -196,7 +196,7 @@ def handle_alphafold_files(
                 f.write(sequence)
             logger.info("Wrote FASTA sequence to %s", fasta_dest)
             fasta_dict = fasta_import(str(fasta_dest))
-            sequence_df = fasta_dict["fasta_df"]
+            amino_acid_sequence_df = fasta_dict["fasta_df"]
         except OSError:
             logger.exception("Failed to write FASTA file %s", fasta_dest)
         except Exception:
@@ -210,7 +210,7 @@ def handle_alphafold_files(
         "cif_df": cif_df,
         "pae_df": pae_df,
         "plddt_df": plddt_df,
-        "sequence_df": sequence_df,
+        "amino_acid_sequence_df": amino_acid_sequence_df,
         "messages": messages,
     }
 
@@ -274,8 +274,8 @@ def get_prot_structure_dfs(entry_id: str) -> dict[str, Any]:
     fasta_file = fasta_files[0]
     try:
         fasta_dict = fasta_import(str(fasta_file))
-        sequence_df = fasta_dict.get("fasta_df")
-        if sequence_df is None:
+        amino_acid_sequence_df = fasta_dict.get("fasta_df")
+        if amino_acid_sequence_df is None:
             msg = f"FASTA importer did not return 'fasta_df' for {fasta_file}"
             logger.error(msg)
             raise RuntimeError(msg)
@@ -290,9 +290,6 @@ def get_prot_structure_dfs(entry_id: str) -> dict[str, Any]:
         msg = f"No JSON files (PAE/pLDDT) found in {prot_dir} for entry '{entry_id}'"
         logger.error(msg)
         raise FileNotFoundError(msg)
-
-    pae_df = None
-    plddt_df = None
 
     try:
         if len(json_files) == 1:
@@ -331,7 +328,7 @@ def get_prot_structure_dfs(entry_id: str) -> dict[str, Any]:
         "cif_df": cif_df,
         "pae_df": pae_df,
         "plddt_df": plddt_df,
-        "sequence_df": sequence_df,
+        "amino_acid_sequence_df": amino_acid_sequence_df,
     }
     if not any(df.empty for df in df_dict.values()):
         success_msg = f"Successfully loaded AlphaFold data for entry '{entry_id}'"
@@ -411,7 +408,7 @@ def fetch_alphafold_protein_structure(
         "cif_df": alpha_dfs["cif_df"],
         "pae_df": alpha_dfs["pae_df"],
         "plddt_df": alpha_dfs["plddt_df"],
-        "sequence_df": alpha_dfs["sequence_df"],
+        "amino_acid_sequence_df": alpha_dfs["amino_acid_sequence_df"],
     }
     messages = alpha_dfs["messages"]
     if not any(df.empty for df in df_dict.values()):

--- a/backend/protzilla/methods/data_analysis.py
+++ b/backend/protzilla/methods/data_analysis.py
@@ -2537,6 +2537,18 @@ class CrossLinkingValidationWithAngstromDeviation(DataAnalysisStep):
     calc_method = staticmethod(validate_with_angstrom_deviation)
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
+        entry_id = inputs["protein_to_validate"]
+        correct_input_step_identifier = steps.get_step_identifier_of_step_with_input(
+            ImportStructurePredictionFromDisk, "entry_id", entry_id
+        ) or steps.get_step_identifier_of_step_with_input(
+            AlphaFoldPredictionLoad, "uniprot_id", entry_id
+        )
+        inputs["cif_df"] = steps.get_step_output(
+            Step, "cif_df", correct_input_step_identifier
+        )
+        inputs["amino_acid_sequence_df"] = steps.get_step_output(
+            Step, "amino_acid_sequence_df", correct_input_step_identifier
+        )
         inputs["crosslinking_df"] = steps.get_step_output(
             Step,
             "crosslinking_df",

--- a/backend/protzilla/methods/data_analysis.py
+++ b/backend/protzilla/methods/data_analysis.py
@@ -65,6 +65,10 @@ from protzilla.data_analysis.crosslinking_validation import (
     bar_plot_of_valid_crosslinks,
 )
 from backend.protzilla.run import Run
+from backend.protzilla.methods.importing import (
+    ImportStructurePredictionFromDisk,
+    AlphaFoldPredictionLoad,
+)
 
 
 class TTestType(Enum):
@@ -2483,7 +2487,7 @@ class CrossLinkingValidationWithAngstromDeviation(DataAnalysisStep):
         return Form(
             label="Ångström Deviation",
             input_fields=[
-                TextField(
+                DropdownField(
                     name="protein_to_validate",
                     label="Protein prediction that should be validated",
                 ),
@@ -2491,6 +2495,21 @@ class CrossLinkingValidationWithAngstromDeviation(DataAnalysisStep):
         )
 
     def modify_form(self, form: Form, run: Run) -> None:
+        # add all loaded protein entry ids to the dropdown of protein_to_validate_field
+        loaded_protein_entry_ids = list(
+            set(
+                run.steps.get_inputs_of_step_type(
+                    ImportStructurePredictionFromDisk, "entry_id"
+                )
+                + run.steps.get_inputs_of_step_type(
+                    AlphaFoldPredictionLoad, "uniprot_id"
+                )
+            )
+        )
+        form["protein_to_validate"].set_options(
+            form_helper.to_choices(loaded_protein_entry_ids)
+        )
+        # create fields for every crosslink
         crosslinkers = self._get_crosslinker_names_from_crosslinker_df(run.steps)
         for crosslinker in crosslinkers:
             field_name = f"{crosslinker}_length"

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -421,7 +421,7 @@ class AlphaFoldPredictionLoad(ImportingStep):
         "cif_df",
         "pae_df",
         "plddt_df",
-        "sequence_df",
+        "amino_acid_sequence_df",
     ]
 
     plot_method = None
@@ -483,7 +483,7 @@ class ImportStructurePredictionFromDisk(ImportingStep):
         "cif_df",
         "pae_df",
         "plddt_df",
-        "sequence_df",
+        "amino_acid_sequence_df",
     ]
 
     def create_form(self):

--- a/backend/protzilla/steps.py
+++ b/backend/protzilla/steps.py
@@ -596,6 +596,29 @@ class StepManager:
                 return step.inputs[input_key]
         return default
 
+    def get_inputs_of_step_type(
+        self,
+        step_types: type[Step] | list[type[Step]],
+        input_key: str,
+    ) -> list[str]:
+        """
+        Get the specific input of all steps that have a specific step type.
+        :param step_types: The types of the relevant steps
+        :param input_key: The key of the desired input in the input dictionary of the step
+        :return: The values of the input of the steps
+        """
+
+        step_types = [step_types] if not isinstance(step_types, list) else step_types
+        inputs = []
+        for step in reversed(self.previous_calculated_steps):
+            print(str(type(step)) + " expected one of these:  " + str(step_types))
+            if (
+                any(isinstance(step, st) for st in step_types)
+                and input_key in step.inputs
+            ):
+                inputs.append(step.inputs[input_key])
+        return inputs
+
     def all_steps_in_section(self, section: str) -> list[Step]:
         """
         Get all steps in a specific section via the section name

--- a/backend/protzilla/steps.py
+++ b/backend/protzilla/steps.py
@@ -506,6 +506,30 @@ class StepManager:
             )
         return instance_identifiers
 
+    def get_step_identifier_of_step_with_input(
+        self,
+        step_types: type[Step] | list[type[Step]],
+        input_key: str,
+        input: str,
+    ) -> str | None:
+        """
+        Get the step identifier of a step with a certain type and a specific input value for one of the input fields.
+        :param step_types: The types of the relevant steps
+        :param input_key: The key of the desired input in the input dictionary of the step
+        :param input: The specific value for the input_key we are looking for.
+        :return: The step identifier of the step with the correct input
+        """
+
+        step_types = [step_types] if not isinstance(step_types, list) else step_types
+        for step in reversed(self.previous_calculated_steps):
+            if (
+                any(isinstance(step, st) for st in step_types)
+                and input_key in step.inputs
+                and step.inputs[input_key] == input
+            ):
+                return step.instance_identifier
+        return None
+
     def get_step_output(
         self,
         step_type: type[Step],
@@ -611,7 +635,6 @@ class StepManager:
         step_types = [step_types] if not isinstance(step_types, list) else step_types
         inputs = []
         for step in reversed(self.previous_calculated_steps):
-            print(str(type(step)) + " expected one of these:  " + str(step_types))
             if (
                 any(isinstance(step, st) for st in step_types)
                 and input_key in step.inputs

--- a/backend/tests/protzilla/data_analysis/test_crosslinking_validation.py
+++ b/backend/tests/protzilla/data_analysis/test_crosslinking_validation.py
@@ -19,9 +19,6 @@ def test_get_position_of_amino_acid_crosslinker_bound_to():
     assert pos == 3
 
 
-@patch(
-    "backend.protzilla.data_analysis.crosslinking_validation.fetch_alphafold_protein_structure"
-)
 @pytest.mark.parametrize(
     "distance, expected",
     [
@@ -31,7 +28,7 @@ def test_get_position_of_amino_acid_crosslinker_bound_to():
         (6.01, False),  # outside bounds
     ],
 )
-def test_validate_with_angstrom_deviation(mock_fetch, distance, expected):
+def test_validate_with_angstrom_deviation(distance, expected):
     # Fake AlphaFold Data
     cif_df = pd.DataFrame(
         {
@@ -43,9 +40,7 @@ def test_validate_with_angstrom_deviation(mock_fetch, distance, expected):
         }
     )
 
-    fasta_df = pd.DataFrame({"Protein Sequence": ["AB"]})
-
-    mock_fetch.return_value = {"cif_df": cif_df, "sequence_df": fasta_df}
+    amino_acid_sequence_df = pd.DataFrame({"Protein Sequence": ["AB"]})
 
     # Fake Crosslink Data
     crosslinking_df = pd.DataFrame(
@@ -66,6 +61,8 @@ def test_validate_with_angstrom_deviation(mock_fetch, distance, expected):
         crosslinking_df,
         protein_to_validate="P12345",
         crosslinker_information=crosslinker_information,
+        amino_acid_sequence_df=amino_acid_sequence_df,
+        cif_df=cif_df,
     )
 
     df = result["crosslinking_result_df"]

--- a/backend/tests/protzilla/importing/test_alphafold_protein_structure_load.py
+++ b/backend/tests/protzilla/importing/test_alphafold_protein_structure_load.py
@@ -109,7 +109,7 @@ def test_fetch_alphafold_returned_keys(tmp_path, monkeypatch):
         "cif_df",
         "pae_df",
         "plddt_df",
-        "sequence_df",
+        "amino_acid_sequence_df",
         "messages",
     }
 
@@ -166,7 +166,7 @@ def test_fetch_alphafold_dfs_exist(tmp_path, monkeypatch):
     assert isinstance(plddt_df, pd.DataFrame)
     assert not plddt_df.empty
 
-    seq_df = out["sequence_df"]
+    seq_df = out["amino_acid_sequence_df"]
     assert isinstance(seq_df, pd.DataFrame)
     assert not seq_df.empty
 
@@ -283,10 +283,10 @@ CA C 2.0
     assert out["plddt_df"]["residueNumber"].tolist() == [1]
     assert out["plddt_df"]["confidenceScore"].tolist() == [90]
 
-    assert isinstance(out["sequence_df"], pd.DataFrame)
-    assert not out["sequence_df"].empty
-    assert out["sequence_df"]["Protein ID"].tolist() == ["Q8WP00-1"]
-    assert out["sequence_df"]["Protein Sequence"].tolist() == ["AAAA"]
+    assert isinstance(out["amino_acid_sequence_df"], pd.DataFrame)
+    assert not out["amino_acid_sequence_df"].empty
+    assert out["amino_acid_sequence_df"]["Protein ID"].tolist() == ["Q8WP00-1"]
+    assert out["amino_acid_sequence_df"]["Protein Sequence"].tolist() == ["AAAA"]
 
     assert any(d.get("level") == logging.INFO for d in out["messages"]) or any(
         "Successfully loaded" in d.get("msg", "") for d in out["messages"]


### PR DESCRIPTION
## Description
fixes #220 
Added a dropdown for selecting protein structure to validate so that the user can only select predicted models for which dataframes were loaded in the same run.
Instead of using fetch_alphafold_protein_structure, we are inserting the relevant dataframes.
Also renamed fasta_df and sequence_df to amino_acid_sequence_df to make it more consistent.

## Changes
Changed form definition in data_analysis.py.
Added two helper functions to steps.py, so that you can get all steps of a certain type with a specific input key and to get the step identifier of a certain step type with a specific input.


## Testing

1. Upload new protein structures via AlphafoldLoad and StructureImport.
2. Add Crosslinking Validation Step. Check that the dropdown contains exactly the loaded proteins.
3. Calculate Crosslinking Validation (p26splussubstrate_XL.xlsx, DSSO length: 10.2, upper_bound: 1, should result in 1 valid crosslink and 6 invalid ones)

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [x] At least one other developer reviewed and approved the changes