### PR TITLE
use step outputs for protein_df

### DIFF
--- a/backend/protzilla/methods/data_analysis.py
+++ b/backend/protzilla/methods/data_analysis.py
@@ -258,7 +258,7 @@ class DifferentialExpressionANOVA(DataAnalysisStep):
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
         inputs["log_base"] = steps.get_step_input(TransformationLog, "log_base")
-        inputs["intensity_df"] = steps.get_step_input(
+        inputs["intensity_df"] = steps.get_step_output(
             Step, "protein_df", inputs["protein_df"]
         )
         inputs["metadata_df"] = steps.metadata_df
@@ -383,7 +383,7 @@ class DifferentialExpressionTTest(DataAnalysisStep):
 
     def insert_dataframes(self, steps: StepManager, inputs) -> dict:
         inputs["log_base"] = steps.get_step_input(TransformationLog, "log_base")
-        inputs["intensity_df"] = steps.get_step_input(
+        inputs["intensity_df"] = steps.get_step_output(
             Step, "protein_df", inputs["protein_df"]
         )
         inputs["metadata_df"] = steps.metadata_df


### PR DESCRIPTION
## Description
fixes #257 
Changes `get_step_input` to `get_step_output` for the relevant steps

## Testing
Use the AML Paper workflow found [here](https://nextcloud.hpi.de/apps/files/files?dir=/PROTzilla_2025). Add an imputation step to the end of the data preprocessing section. Perform that, then perform the t-test. Note how there are no missing samples / NaN values left compared to the previous state

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
