### PR TITLE
fix single checkbox state issue

### DIFF
--- a/frontend/src/components/core/shared/input-fields/checkbox-input-fields/single-checkbox/single-checkbox-input-field.tsx
+++ b/frontend/src/components/core/shared/input-fields/checkbox-input-fields/single-checkbox/single-checkbox-input-field.tsx
@@ -21,7 +21,6 @@ export const SingleCheckboxInputField: React.FC<SingleCheckboxInputFieldProps> =
   ...props
 }) => {
   const [isChecked, setIsChecked] = useState<boolean>(() => {
-    onChange(initialValue ?? false);
     return initialValue ?? false;
   });
 


### PR DESCRIPTION
## Description
fixes #249 
Removes a call to `onChange` that gets called on the form initialisation, esentially prompting the back-end to invalidate the step.

## Changes
Removed bad call in the SingleCheckboxInputField

## Testing
Create a new run with the MaxQuantImport step, import some stuff and then navigate back to that step. Previously, the step would be instantly invalidated. Now, the step should stay validated and you shouldn't be forced to re-upload the data. Same thing goes for other steps such as the t-test.

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
