### PR TITLE
264 tidy buttons

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^2.0.4",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@mui/material": "^6.4.12",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      "@dagrejs/dagre":
+        specifier: ^2.0.4
+        version: 2.0.4
       "@emotion/react":
         specifier: ^11.14.0
         version: 11.14.0(@types/react@18.3.24)(react@18.3.1)
@@ -486,6 +489,20 @@ packages:
         integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==,
       }
     engines: { node: ">=18" }
+
+  "@dagrejs/dagre@2.0.4":
+    resolution:
+      {
+        integrity: sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA==,
+      }
+    dependencies:
+      "@dagrejs/graphlib": 3.0.4
+
+  "@dagrejs/graphlib@3.0.4":
+    resolution:
+      {
+        integrity: sha512-HxZ7fCvAwTLCWCO0WjDkzAFQze8LdC6iOpKbetDKHIuDfIgMlIzYzqZ4nxwLlclQX+3ZVeZ1K2OuaOE2WWcyOg==,
+      }
 
   "@emnapi/core@1.5.0":
     resolution:

--- a/frontend/src/components/app/run-screen/node-editor/node-editor-layout.tsx
+++ b/frontend/src/components/app/run-screen/node-editor/node-editor-layout.tsx
@@ -1,0 +1,44 @@
+import dagre from "@dagrejs/dagre";
+import type { Edge } from "@xyflow/react";
+
+import type { StepNodeType } from "./StepNode";
+
+const DAGRE_NODE_WIDTH = 260;
+const DAGRE_NODE_HEIGHT = 72;
+const DAGRE_NODE_SEP = 40;
+const DAGRE_RANK_SEP = 80;
+const DAGRE_RANK_DIR = "TB";
+
+export const layoutNodesWithDagre = (nodes: StepNodeType[], edges: Edge[]): StepNodeType[] => {
+  if (nodes.length === 0) return nodes;
+
+  const dagreGraph = new dagre.graphlib.Graph();
+  dagreGraph.setDefaultEdgeLabel(() => ({}));
+  dagreGraph.setGraph({
+    rankdir: DAGRE_RANK_DIR,
+    nodesep: DAGRE_NODE_SEP,
+    ranksep: DAGRE_RANK_SEP,
+  });
+
+  nodes.forEach((node) => {
+    dagreGraph.setNode(node.id, { width: DAGRE_NODE_WIDTH, height: DAGRE_NODE_HEIGHT });
+  });
+  edges.forEach((edge) => {
+    dagreGraph.setEdge(edge.source, edge.target);
+  });
+
+  dagre.layout(dagreGraph);
+
+  return nodes.map((node) => {
+    const layoutedNode = dagreGraph.node(node.id);
+    if (!layoutedNode) return node;
+
+    return {
+      ...node,
+      position: {
+        x: layoutedNode.x - DAGRE_NODE_WIDTH / 2,
+        y: layoutedNode.y - DAGRE_NODE_HEIGHT / 2,
+      },
+    };
+  });
+};

--- a/frontend/src/components/app/run-screen/node-editor/node-editor.tsx
+++ b/frontend/src/components/app/run-screen/node-editor/node-editor.tsx
@@ -1,22 +1,32 @@
 import "@xyflow/react/dist/style.css";
 import { useNotification } from "@protzilla/app";
-import { BackendForm, FlexRow, Icon, RedButton, SecondaryButton } from "@protzilla/core";
-import { color, spacing } from "@protzilla/theme";
-import type { Step } from "@protzilla/utils";
 import {
-  callApiWithParameters,
-  emptyRunData,
-  SectionIDs,
-  supportedSections,
-} from "@protzilla/utils";
-import type { Connection, Edge, EdgeChange, NodeChange, NodeTypes } from "@xyflow/react";
+  BackendForm,
+  FlexRow,
+  GrayButton,
+  Icon,
+  RedButton,
+  SecondaryButton,
+} from "@protzilla/core";
+import { color, spacing } from "@protzilla/theme";
+import type { Section, Step } from "@protzilla/utils";
+import { callApiWithParameters, SectionIDs, translateGlobalToSectionIndex } from "@protzilla/utils";
+import type {
+  Connection,
+  Edge,
+  EdgeChange,
+  NodeChange,
+  NodeTypes,
+  ReactFlowInstance,
+} from "@xyflow/react";
 import { applyEdgeChanges, applyNodeChanges, Panel, ReactFlow } from "@xyflow/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { styled } from "styled-components";
 
 import { StepSelection } from "../step-selection";
 import type { HoveredHandleMeta, StepNodeType } from "./StepNode";
 import StepNode from "./StepNode";
+import { layoutNodesWithDagre } from "./node-editor-layout";
 import { NodeEditorProps } from "./node-editor.props";
 
 const nodeTypes: NodeTypes = { step: StepNode };
@@ -25,19 +35,6 @@ const StyledRow = styled(FlexRow)`
   gap: ${spacing("verySmall")};
   align-items: flex-start;
   height: 100%;
-`;
-
-const StyledFlowColumn = styled.div`
-  width: calc(25vw + 24px);
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-`;
-
-const StyledFlowCanvas = styled.div`
-  flex: 1;
-  min-height: 0;
 `;
 
 const StyledDivider = styled.div`
@@ -80,21 +77,7 @@ export const NodeEditor: React.FC<NodeEditorProps> = ({
   runData,
 }) => {
   const notify = useNotification();
-
-  //
-  // State
-  //
-
-  const [nodes, setNodes] = useState<StepNodeType[]>([]);
-  const [edges, setEdges] = useState<Edge[]>([]);
-  const [selectedEdge, setSelectedEdge] = useState<Edge | null>(null);
-
-  // Mouse-Over info for each handle, displayed in the corner
-  const [hoveredHandleMeta, setHoveredHandleMeta] = useState<HoveredHandleMeta>({
-    isActive: false,
-    direction: "Input",
-    type: "protein_df",
-  });
+  const reactFlowInstanceRef = useRef<ReactFlowInstance<StepNodeType> | null>(null);
 
   const onAddStep = () => {
     notify({ type: "success", title: "Step added", message: "Successfully added step" });
@@ -102,59 +85,21 @@ export const NodeEditor: React.FC<NodeEditorProps> = ({
   };
 
   //
-  // Data syncing
+  // ReactFlow initialisation
   //
 
-  useEffect(() => {
-    if (runData === emptyRunData) return;
-
-    const syncNodes = runData.displayed_steps.map((step: Step) => ({
-      id: step.id,
-      type: "step",
-      position: step.visual_data?.node_position ?? { x: 0, y: 0 },
-      data: {
-        step: step,
-        section: step.section,
-        isSelected: runData.current_step_id === step.id,
-        navigateOrRefreshSteps,
-        setHoveredHandleMeta,
-      },
-    }));
-
-    setNodes(syncNodes as StepNodeType[]);
-  }, [runData, navigateOrRefreshSteps]);
-
-  const fetchEdges = useCallback(async () => {
-    try {
-      const res = await callApiWithParameters("get_edges/", { run_name: runName });
-      if (res.data) setEdges(res.data as Edge[]);
-    } catch (err) {
-      console.error("Failed to fetch edges", err);
-    }
-  }, [runName]);
-
-  useEffect(() => {
-    void fetchEdges();
-  }, [fetchEdges, runData.current_step_id]); // Refresh edges when step changes
-
-  //
-  // Handlers
-  //
+  const [nodes, setNodes] = useState<StepNodeType[]>([]);
+  const [edges, setEdges] = useState<Edge[]>([]);
+  const [selectedEdge, setSelectedEdge] = useState<Edge | null>(null);
 
   const onNodesChange = useCallback((changes: NodeChange<StepNodeType>[]) => {
     setNodes((nodesSnapshot) => applyNodeChanges(changes, nodesSnapshot));
   }, []);
-
   const onEdgesChange = useCallback((changes: EdgeChange[]) => {
     setEdges((edgesSnapshot) => applyEdgeChanges(changes, edgesSnapshot));
   }, []);
-
-  const onEdgeClick = useCallback((_event: React.MouseEvent, edge: Edge) => {
-    setSelectedEdge(edge);
-  }, []);
-
-  const onPaneClick = useCallback(() => {
-    setSelectedEdge(null);
+  const onReactFlowInit = useCallback((instance: ReactFlowInstance<StepNodeType>) => {
+    reactFlowInstanceRef.current = instance;
   }, []);
 
   const onNodeDragStop = useCallback(
@@ -171,22 +116,18 @@ export const NodeEditor: React.FC<NodeEditorProps> = ({
     [navigateOrRefreshSteps, runName],
   );
 
-  const onConnect = useCallback(
-    (params: Connection) => {
-      void callApiWithParameters("connect_steps/", {
-        run_name: runName,
-        connection: params,
-      }).then((response) => {
-        notify({
-          type: response.success ? "success" : "error",
-          title: response.message.title,
-          message: response.message.msg,
-        });
-        void fetchEdges();
-      });
-    },
-    [fetchEdges, notify, runName],
-  );
+  const getEdgesFromRunData = useCallback(async (): Promise<Edge[]> => {
+    const res = await callApiWithParameters("get_edges/", { run_name: runName });
+    return res.data as Edge[];
+  }, [runName]);
+
+  const onEdgeClick = useCallback((_event: React.MouseEvent, edge: Edge) => {
+    setSelectedEdge(edge);
+  }, []);
+
+  const onPaneClick = useCallback(() => {
+    setSelectedEdge(null);
+  }, []);
 
   const removeCurrentConnection = useCallback(() => {
     if (!selectedEdge) return;
@@ -205,54 +146,162 @@ export const NodeEditor: React.FC<NodeEditorProps> = ({
         message: response.message.msg,
       });
       setSelectedEdge(null);
-      void fetchEdges();
+      void getEdgesFromRunData().then((newEdges) => {
+        setEdges(newEdges);
+      });
     });
-  }, [fetchEdges, notify, runName, selectedEdge]);
+  }, [getEdgesFromRunData, notify, runName, selectedEdge]);
+
+  const onAutoLayout = useCallback(() => {
+    const layoutedNodes = layoutNodesWithDagre(nodes, edges);
+    setNodes(layoutedNodes);
+    void reactFlowInstanceRef.current?.fitView({ padding: 0.2, duration: 200 });
+
+    const persistLayout = async () => {
+      try {
+        await Promise.all(
+          layoutedNodes.map((node) =>
+            callApiWithParameters("set_step_pos/", {
+              run_name: runName,
+              step_id: node.id,
+              x: node.position.x,
+              y: node.position.y,
+            }),
+          ),
+        );
+        notify({
+          type: "success",
+          title: "Layout updated",
+          message: "Node positions saved",
+        });
+        navigateOrRefreshSteps();
+      } catch {
+        notify({
+          type: "error",
+          title: "Layout failed",
+          message: "Could not save node positions",
+        });
+      }
+    };
+
+    void persistLayout();
+  }, [edges, navigateOrRefreshSteps, nodes, notify, runName]);
+
+  const onConnect = useCallback(
+    (params: Connection) => {
+      console.log(params);
+      void callApiWithParameters("connect_steps/", {
+        run_name: runName,
+        connection: params,
+      }).then((response) => {
+        notify({
+          type: response.success ? "success" : "error",
+          title: response.message.title,
+          message: response.message.msg,
+        });
+        void getEdgesFromRunData().then((newEdges) => {
+          setEdges(newEdges);
+        });
+      });
+    },
+    [getEdgesFromRunData, notify, runName],
+  );
+
+  // Mouse-Over info for each handle, displayed in the corner
+  const [hoveredHandleMeta, setHoveredHandleMeta] = useState<HoveredHandleMeta>({
+    isActive: false,
+    direction: "Input",
+    type: "protein_df",
+  });
+
+  //
+  // Run data
+  //
 
   const deleteCurrentStep = async () => {
     await callApiWithParameters("delete_step/", {
       run_name: runName,
-      step_id: runData.current_step_id,
+      section: runData.current_section,
+      index: translateGlobalToSectionIndex(runData.current_step_index, sections).index,
     }).then((response) => {
       notify({
         type: response.success ? "success" : "error",
         title: response.message,
       });
-      navigateOrRefreshSteps();
     });
+    navigateOrRefreshSteps();
   };
 
-  //
-  // Derived view state
-  //
+  const sections: Section[] = runData.displayed_steps;
+  const currentSectionId = runData.current_section as SectionIDs;
+  const currentSection = sections.find((section) => section.id === currentSectionId);
 
-  const currentStep = useMemo(
-    () => runData.displayed_steps.find((s) => s.id === runData.current_step_id),
-    [runData],
-  );
-
-  // Fallback
-  if (runData === emptyRunData || !currentStep) {
-    return <h1>Loading editor...</h1>;
-  }
-
+  const currentStepCalculationStatus = currentSection?.steps[runData.current_step_index]?.status;
   const buttonText =
-    currentStep.status === "complete"
+    currentStepCalculationStatus === "complete"
       ? "Next"
-      : (runData.current_section as SectionIDs) === SectionIDs.Importing
+      : currentSectionId === SectionIDs.Importing
         ? "Import"
         : "Calculate";
 
+  useEffect(() => {
+    console.log("Run Data", runData);
+    const effectSections = runData.displayed_steps;
+    setNodes((nodesSnapshot) => {
+      const newNodes: StepNodeType[] = [];
+      let yOffset = 0;
+      let flatStepIndex = 0;
+
+      effectSections.forEach((section: Section) => {
+        section.steps.forEach((step: Step, index: number) => {
+          const isSelected =
+            currentSectionId === section.id && runData.current_step_index === flatStepIndex;
+
+          const oldMatchingNode = nodesSnapshot.find((node) => node.id == step.id);
+          const savedPosition = step.visual_data?.node_position;
+          const position = oldMatchingNode
+            ? oldMatchingNode.position
+            : savedPosition
+              ? { x: savedPosition.x, y: savedPosition.y }
+              : { x: 0, y: yOffset };
+
+          newNodes.push({
+            id: step.id,
+            type: "step",
+            position: position,
+            data: {
+              step: step,
+              step_index_within_section: index,
+              section: section.id,
+              isSelected: isSelected,
+              navigateOrRefreshSteps: navigateOrRefreshSteps,
+              setHoveredHandleMeta: setHoveredHandleMeta,
+            },
+          });
+
+          flatStepIndex += 1;
+          yOffset += 60;
+        });
+      });
+      return newNodes;
+    });
+
+    void getEdgesFromRunData().then((newEdges) => {
+      setEdges(newEdges);
+    });
+  }, [currentSectionId, getEdgesFromRunData, navigateOrRefreshSteps, runData]);
+
   const stepSelectionProps = {
     runName: runName,
+    index: 0,
     onAddStep: onAddStep,
   };
 
   return (
     <StyledRow>
-      <StyledFlowColumn>
+      <div style={{ width: "calc(25vw + 24px)", height: "100vh" }}>
         <StyledStepButtonsRow>
-          {supportedSections.map((section) => (
+          {sections.map((section) => (
             <StepSelection
               key={`add-button-for-section-${section.id as string}`}
               section={section.id}
@@ -269,60 +318,68 @@ export const NodeEditor: React.FC<NodeEditorProps> = ({
           ))}
         </StyledStepButtonsRow>
 
-        <StyledFlowCanvas>
-          <ReactFlow
-            key={runName}
-            nodes={nodes}
-            edges={edges}
-            nodeTypes={nodeTypes}
-            onNodesChange={onNodesChange}
-            onEdgesChange={onEdgesChange}
-            onEdgeClick={onEdgeClick}
-            onPaneClick={onPaneClick}
-            onNodeDragStop={onNodeDragStop}
-            onConnect={onConnect}
-            fitView
-          >
-            <Panel position="top-left">
-              <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
-                <RedButton onClick={() => void deleteCurrentStep()}>Remove current step</RedButton>
-                {selectedEdge && (
-                  <RedButton onClick={removeCurrentConnection} isDisabled={!selectedEdge}>
-                    Remove selected connection
-                  </RedButton>
-                )}
-              </div>
-            </Panel>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onEdgeClick={onEdgeClick}
+          onPaneClick={onPaneClick}
+          onNodeDragStop={onNodeDragStop}
+          onConnect={onConnect}
+          onInit={onReactFlowInit}
+          fitView
+        >
+          <Panel position="top-left">
+            <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+              <GrayButton onClick={onAutoLayout}>Tidy layout</GrayButton>
+              <RedButton onClick={() => void deleteCurrentStep()}>Remove current step</RedButton>
+              <RedButton onClick={removeCurrentConnection} isDisabled={!selectedEdge}>
+                Remove current connection
+              </RedButton>
+            </div>
+          </Panel>
 
-            <Panel position="top-right">
-              {hoveredHandleMeta.isActive && (
-                <div style={{ textAlign: "right" }}>
-                  <p>{hoveredHandleMeta.direction}</p>
-                  <p>{hoveredHandleMeta.type}</p>
-                </div>
-              )}
-            </Panel>
-          </ReactFlow>
-        </StyledFlowCanvas>
-      </StyledFlowColumn>
+          <Panel position="top-right">
+            {hoveredHandleMeta.isActive && (
+              <div style={{ textAlign: "right" }}>
+                <p>{hoveredHandleMeta.direction}</p>
+                <p>{hoveredHandleMeta.type}</p>
+              </div>
+            )}
+          </Panel>
+        </ReactFlow>
+      </div>
 
       <StyledDivider />
 
+      {/* TODO: Well, this is stupid. We probably need to redefine this component.
+      previousStepCalculationStatus does not make a lot of sense with the new system.
+      onNext also isn't really a thing anymore I suppose.
+      onChange suffers from similar problems, but should be doable.
+      Gotta discuss this in a meeting
+    */}
       <StyledFormColumn>
         <BackendForm
           runName={runName}
           buttonText={buttonText}
           previousStepCalculationStatus={"complete"}
-          currentStepCalculationStatus={currentStep.status}
-          current_step_id={runData.current_step_id}
-          isLastStep={!runData.recommended_next_step_id}
+          currentStepCalculationStatus={currentStepCalculationStatus}
+          current_step_index={runData.current_step_index}
+          isLastStep={
+            runData.current_step_index >=
+            sections
+              .map((section) => section.steps.length)
+              .reduce((acc: number, val: number) => acc + val, 0) -
+              1
+          }
           onNext={() => {
-            navigateOrRefreshSteps(runData.recommended_next_step_id);
+            console.log("TODO: A vulture ate this callback! Come up with something better.");
           }}
           onSubmit={onFormSubmit}
           onChange={() => {
-            // Quite a radical solution, but sadly works
-            navigateOrRefreshSteps();
+            console.log("TODO: A vulture ate this callback! Come up with something better.");
           }}
         />
       </StyledFormColumn>

--- a/frontend/src/components/app/run-screen/node-editor/node-editor.tsx
+++ b/frontend/src/components/app/run-screen/node-editor/node-editor.tsx
@@ -91,6 +91,29 @@ export const NodeEditor: React.FC<NodeEditorProps> = ({
   const [nodes, setNodes] = useState<StepNodeType[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
   const [selectedEdge, setSelectedEdge] = useState<Edge | null>(null);
+  const dragStartPositionsRef = useRef<Record<string, { x: number; y: number } | undefined>>({});
+
+  const getNodeRect = useCallback((node: StepNodeType) => {
+    const width = node.width ?? 260;
+    const height = node.height ?? 72;
+    return {
+      x: node.position.x,
+      y: node.position.y,
+      width,
+      height,
+    };
+  }, []);
+
+  const nodesOverlap = useCallback(
+    (node: StepNodeType, other: StepNodeType) => {
+      const a = getNodeRect(node);
+      const b = getNodeRect(other);
+      return (
+        a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y
+      );
+    },
+    [getNodeRect],
+  );
 
   const onNodesChange = useCallback((changes: NodeChange<StepNodeType>[]) => {
     setNodes((nodesSnapshot) => applyNodeChanges(changes, nodesSnapshot));
@@ -102,8 +125,26 @@ export const NodeEditor: React.FC<NodeEditorProps> = ({
     reactFlowInstanceRef.current = instance;
   }, []);
 
+  const onNodeDragStart = useCallback((_event: unknown, node: StepNodeType) => {
+    dragStartPositionsRef.current[node.id] = { x: node.position.x, y: node.position.y };
+  }, []);
+
   const onNodeDragStop = useCallback(
     (_event: unknown, node: StepNodeType) => {
+      const hasOverlap = nodes.some((other) => other.id !== node.id && nodesOverlap(node, other));
+      if (hasOverlap) {
+        const previousPosition = dragStartPositionsRef.current[node.id];
+        if (!previousPosition) return;
+        setNodes((nodesSnapshot) =>
+          nodesSnapshot.map((snapshotNode) =>
+            snapshotNode.id === node.id
+              ? { ...snapshotNode, position: previousPosition }
+              : snapshotNode,
+          ),
+        );
+        return;
+      }
+
       void callApiWithParameters("set_step_pos/", {
         run_name: runName,
         step_id: node.id,
@@ -113,7 +154,7 @@ export const NodeEditor: React.FC<NodeEditorProps> = ({
         navigateOrRefreshSteps();
       });
     },
-    [navigateOrRefreshSteps, runName],
+    [navigateOrRefreshSteps, nodes, nodesOverlap, runName],
   );
 
   const getEdgesFromRunData = useCallback(async (): Promise<Edge[]> => {
@@ -326,6 +367,7 @@ export const NodeEditor: React.FC<NodeEditorProps> = ({
           onEdgesChange={onEdgesChange}
           onEdgeClick={onEdgeClick}
           onPaneClick={onPaneClick}
+          onNodeDragStart={onNodeDragStart}
           onNodeDragStop={onNodeDragStop}
           onConnect={onConnect}
           onInit={onReactFlowInit}


### PR DESCRIPTION
## Description
fixes #264 + #265 
Implemented tidy buttons and position-reset when a node are dropped on another node.

## Changes
- Added a Tidy layout action to auto-arrange nodes.
- Prevented node overlap by restoring the previous position when a node is dropped on another node.

## Known issue
- when "spawning" new nodes they still overlap :(

## Testing
Some frontend testing

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [ ] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
