### PR TITLE
fix: adapt only-import and only-import-and-filtering-workflows to node editor format

### DIFF
--- a/backend/protzilla/data_analysis/classification_helper.py
+++ b/backend/protzilla/data_analysis/classification_helper.py
@@ -71,7 +71,7 @@ def perform_grid_search_cv(
     cv=None,
     n_iter=10,
 ):
-    #make sure refit is never None
+    # make sure refit is never None
     if model_selection_scoring is None:
         model_selection_scoring = False
 

--- a/backend/protzilla/methods/data_analysis.py
+++ b/backend/protzilla/methods/data_analysis.py
@@ -1503,28 +1503,28 @@ class ClassificationRandomForest(ClassificationStep):
                     label="Choose the size of the validation data set (you can either enter the absolute number of validation "
                     "samples or a number between 0.0 and 1.0 to represent the percentage of validation samples)",
                     value=0.20,
-                    isVisible = False,
+                    isVisible=False,
                 ),
                 NumberField(
                     name="n_splits",
                     label="Number of folds",
                     min=2,
                     value=5,
-                    isVisible = False,
+                    isVisible=False,
                 ),
                 DropdownField(
                     name="shuffle",
                     label="Whether to shuffle the data before splitting into batches",
                     options=YesNo,
                     value=YesNo.yes,
-                    isVisible = False,
+                    isVisible=False,
                 ),
                 NumberField(
                     name="n_repeats",
                     label="Number of times cross-validator needs to be repeated",
                     min=1,
                     value=10,
-                    isVisible = False,
+                    isVisible=False,
                 ),
                 NumberField(
                     name="random_state_cv",
@@ -1538,7 +1538,7 @@ class ClassificationRandomForest(ClassificationStep):
                     name="p_samples",
                     label="Size of the test sets",
                     value=1,
-                    isVisible = False,
+                    isVisible=False,
                 ),
                 MultiSelectField(
                     name="scoring",
@@ -1597,20 +1597,28 @@ class ClassificationRandomForest(ClassificationStep):
         n_repeats_field: NumberField = self.form["n_repeats"]
         p_samples_field: NumberField = self.form["p_samples"]
 
-
         if validation_strategy_field.value in [
             ClassificationValidationStrategy.k_fold.value,
             ClassificationValidationStrategy.stratified_k_fold.value,
         ]:
             n_splits_field.isVisible = True
             shuffle_field.isVisible = True
-        elif validation_strategy_field.value == ClassificationValidationStrategy.repeated_k_fold.value:
+        elif (
+            validation_strategy_field.value
+            == ClassificationValidationStrategy.repeated_k_fold.value
+        ):
             n_splits_field.isVisible = True
             shuffle_field.isVisible = True
             n_repeats_field.isVisible = True
-        elif validation_strategy_field.value == ClassificationValidationStrategy.leave_p_out.value:
+        elif (
+            validation_strategy_field.value
+            == ClassificationValidationStrategy.leave_p_out.value
+        ):
             p_samples_field.isVisible = True
-        elif validation_strategy_field.value == ClassificationValidationStrategy.manual.value:
+        elif (
+            validation_strategy_field.value
+            == ClassificationValidationStrategy.manual.value
+        ):
             train_val_split_field.isVisible = True
 
     calc_method = staticmethod(random_forest)
@@ -1664,28 +1672,28 @@ class ClassificationSVM(ClassificationStep):
                     label="Choose the size of the validation data set (you can either enter the absolute number of validation "
                     "samples or a number between 0.0 and 1.0 to represent the percentage of validation samples)",
                     value=0.20,
-                    isVisible = False,
+                    isVisible=False,
                 ),
                 NumberField(
                     name="n_splits",
                     label="Number of folds",
                     min=2,
                     value=5,
-                    isVisible = False,
+                    isVisible=False,
                 ),
                 DropdownField(
                     name="shuffle",
                     label="Whether to shuffle the data before splitting into batches",
                     options=YesNo,
                     value=YesNo.yes,
-                    isVisible = False,
+                    isVisible=False,
                 ),
                 NumberField(
                     name="n_repeats",
                     label="Number of times cross-validator needs to be repeated",
                     min=1,
                     value=10,
-                    isVisible = False,
+                    isVisible=False,
                 ),
                 NumberField(
                     name="random_state_cv",
@@ -1699,7 +1707,7 @@ class ClassificationSVM(ClassificationStep):
                     name="p_samples",
                     label="Size of the test sets",
                     value=1,
-                    isVisible = False,
+                    isVisible=False,
                 ),
                 MultiSelectField(
                     name="scoring",
@@ -1763,13 +1771,22 @@ class ClassificationSVM(ClassificationStep):
         ]:
             n_splits_field.isVisible = True
             shuffle_field.isVisible = True
-        elif validation_strategy_field.value == ClassificationValidationStrategy.repeated_k_fold.value:
+        elif (
+            validation_strategy_field.value
+            == ClassificationValidationStrategy.repeated_k_fold.value
+        ):
             n_splits_field.isVisible = True
             shuffle_field.isVisible = True
             n_repeats_field.isVisible = True
-        elif validation_strategy_field.value == ClassificationValidationStrategy.leave_p_out.value:
+        elif (
+            validation_strategy_field.value
+            == ClassificationValidationStrategy.leave_p_out.value
+        ):
             p_samples_field.isVisible = True
-        elif validation_strategy_field.value == ClassificationValidationStrategy.manual.value:
+        elif (
+            validation_strategy_field.value
+            == ClassificationValidationStrategy.manual.value
+        ):
             train_val_split_field.isVisible = True
 
     calc_method = staticmethod(svm)

--- a/backend/user_data/workflows/only_import.yaml
+++ b/backend/user_data/workflows/only_import.yaml
@@ -1,11 +1,33 @@
+current_step_id: s00001_MaxQuantImport
+df_mode: Standard
+graph_edges:
+- !!python/tuple
+  - s00001_MaxQuantImport
+  - s00002_MetadataImport
+  - source_handle: protein_df
+    target_handle: protein_df
+id_clock: 2
 steps:
-  - form_inputs:
-      intensity_name: iBAQ
-      map_to_uniprot: false
-      aggregation_method: Sum
-    inputs: { }
-    type: MaxQuantImport
-  - form_inputs:
-      feature_orientation: Columns (samples in rows, features in columns)
-    inputs: { }
-    type: MetadataImport
+- form_inputs:
+    aggregation_method: Sum
+    file_path: null
+    ignore_only_identified_by_site: false
+    intensity_name: iBAQ
+    map_to_uniprot: false
+  inputs: {}
+  instance_identifier: s00001_MaxQuantImport
+  type: MaxQuantImport
+  visual_data:
+    node_position:
+      x: -171.80483018600978
+      y: -442.4784777432139
+- form_inputs:
+    feature_orientation: Columns (samples in rows, features in columns)
+    file_path: null
+  inputs: {}
+  instance_identifier: s00002_MetadataImport
+  type: MetadataImport
+  visual_data:
+    node_position:
+      x: -171.80483018600978
+      y: -290.50263564030695

--- a/backend/user_data/workflows/only_import_and_filter_proteins.yaml
+++ b/backend/user_data/workflows/only_import_and_filter_proteins.yaml
@@ -1,17 +1,48 @@
+current_step_id: s00001_MaxQuantImport
+df_mode: Standard
+graph_edges:
+- !!python/tuple
+  - s00001_MaxQuantImport
+  - s00002_MetadataImport
+  - source_handle: protein_df
+    target_handle: protein_df
+- !!python/tuple
+  - s00001_MaxQuantImport
+  - s00003_FilterProteinsBySamplesMissing
+  - source_handle: protein_df
+    target_handle: protein_df
+id_clock: 3
 steps:
-  - form_inputs:
-      intensity_name: iBAQ
-      map_to_uniprot: false
-      aggregation_method: Sum
-    inputs: { }
-    type: MaxQuantImport
-  - form_inputs:
-      feature_orientation: Columns (samples in rows, features in columns)
-    inputs: { }
-    type: MetadataImport
-  - form_inputs:
-      percentage: 0.5
-    inputs: { }
-    plot_inputs:
-      graph_type: Bar chart
-    type: FilterProteinsBySamplesMissing
+- form_inputs:
+    aggregation_method: Sum
+    file_path: null
+    ignore_only_identified_by_site: false
+    intensity_name: iBAQ
+    map_to_uniprot: false
+  inputs: {}
+  instance_identifier: s00001_MaxQuantImport
+  type: MaxQuantImport
+  visual_data:
+    node_position:
+      x: -171.80483018600978
+      y: -442.4784777432139
+- form_inputs:
+    feature_orientation: Columns (samples in rows, features in columns)
+    file_path: null
+  inputs: {}
+  instance_identifier: s00002_MetadataImport
+  type: MetadataImport
+  visual_data:
+    node_position:
+      x: 149.16189082791004
+      y: -290.50263564030695
+- form_inputs:
+    graph_type: Bar chart
+    percentage: 0.5
+  inputs: {}
+  instance_identifier: s00003_FilterProteinsBySamplesMissing
+  type: FilterProteinsBySamplesMissing
+  visual_data:
+    node_position:
+      x: -256.05225879191096
+      y: -298.2342679234283


### PR DESCRIPTION
## Description
fixes #285 
Adapted only-import and only-import-and-filtering-workflows to the node editor format.
<img width="486" height="193" alt="grafik" src="https://github.com/user-attachments/assets/9988010a-2d40-4ed3-8514-ab638a204692" />
<img width="494" height="376" alt="grafik" src="https://github.com/user-attachments/assets/bb46333f-2dd9-4ff7-97ad-83773d11edc3" />



## Changes
Changed workflows in backend/user_data/workflows/only_import.yaml and backend/user_data/workflows/only_import_and_filter_proteins.yaml
The other files are only changed by black.


## Testing
Create a only-import and only-import-and-filtering workflow and check that the right steps exist.

## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [ ] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
