### PR TITLE
feat: add more elaborate selection of the next step after a step was …

### DIFF
--- a/backend/protzilla/step_manager.py
+++ b/backend/protzilla/step_manager.py
@@ -294,6 +294,7 @@ class StepManager:
                     preceeding_step_of_child_step.instance_identifier
                 ):
                     return preceeding_step_of_child_step.instance_identifier
+        return None
 
     def goto_step(self, step_id: StepID) -> None:
         """

--- a/backend/protzilla/step_manager.py
+++ b/backend/protzilla/step_manager.py
@@ -119,6 +119,14 @@ class StepManager:
         descendant_ids = list(nx.descendants(self.graph, step_id))
         return [self.all_steps[step_id] for step_id in descendant_ids]
 
+    def immediate_succeeding_steps(self, step_id: StepID) -> list[Step]:
+        """
+        :param step_id: ID of step of interest
+        :return: List of all immediate successors of the given step (all the child nodes in the graph)
+        """
+        child_ids = list(self.graph.successors(step_id))
+        return [self.all_steps[step_id] for step_id in child_ids]
+
     def step_is_terminal(self, step_id: StepID) -> bool:
         return int(self.graph.out_degree(step_id)) == 0
 
@@ -251,12 +259,41 @@ class StepManager:
     def recommended_next_step_id(self) -> StepID | None:
         """
         Mainly for front-end. Instance identifier of the next step to navigate to when pressing the "Next" button.
-
-        :return: The recommended next step identifier or None if we are at a terminal step
+        If the step is a terminal step, the next step is an arbitrary computable step.
+        Otherwise, if there is a computable immediate successor step, that step is picked as the next step.
+        Otherwise, the next step is a computable preceding step of one of the immediate successors.
+        :return: The recommended next step identifier or None if all steps are already calculated.
         """
+
+        def _possible_next_step(step_id: StepID) -> bool:
+            return (
+                self.calc_dependencies_met_for_step(step_id)
+                and self.all_steps[step_id].calculation_status != "complete"
+            )
+
         if self.is_at_terminal_step:
+            for step_id in self.all_step_ids:
+                if _possible_next_step(step_id):
+                    return step_id
+            # all steps are calculated
             return None
-        return list(self.graph.successors(self.current_selected_step_id))[0]
+        else:
+            for arbitrary_child_step in self.immediate_succeeding_steps(
+                self.current_selected_step_id
+            ):
+                if _possible_next_step(arbitrary_child_step.instance_identifier):
+                    return arbitrary_child_step.instance_identifier
+            # none of the child steps can be calculated right now
+            arbitrary_child_step = self.immediate_succeeding_steps(
+                self.current_selected_step_id
+            )[0]
+            for preceeding_step_of_child_step in self.preceding_steps(
+                arbitrary_child_step.instance_identifier
+            ):
+                if _possible_next_step(
+                    preceeding_step_of_child_step.instance_identifier
+                ):
+                    return preceeding_step_of_child_step.instance_identifier
 
     def goto_step(self, step_id: StepID) -> None:
         """


### PR DESCRIPTION
## Description
fixes #287 -> Changed how the next step is picked when clicking the "Next"-Button after a step was calculated.
If a step is a terminal step, the next step is an arbitrary computable step. Otherwise, if there is a computable immediate successor step, it is chosen as the next step. Otherwise, the next step is a computable preceding step of one of the immediate successors.
If all steps are already computed, there won't be a next step.

## Changes
backend/protzilla/step_manager.py: Introduced the function immediate_succeeding_steps and adapted the recommended_next_step_id function.


## Testing
Create a workflow and only navigate between the steps using the "Next"-Button. Check that the behaviour of the "Next"-Button matches the behaviour you would expect based on the acceptance criteria of the issue.

E.g. test the standard workflow with some small modifications:
<img width="490" height="507" alt="grafik" src="https://github.com/user-attachments/assets/40e174e6-0e50-48d6-89fa-bdc3d87408d2" />


## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
