### PR TITLE
feat: add serialization for non yaml serializable data

### DIFF
--- a/backend/protzilla/data_analysis/classification.py
+++ b/backend/protzilla/data_analysis/classification.py
@@ -14,6 +14,7 @@ from backend.protzilla.data_analysis.classification_helper import (
     perform_grid_search_cv,
     perform_train_test_split,
 )
+from backend.protzilla.steps import OutputItem, OutputType
 from backend.protzilla.utilities.transform_dfs import (
     is_long_format,
     long_to_wide,
@@ -243,7 +244,7 @@ def random_forest(
     y_test = decode_labels(encoding_mapping, y_test)
     y_train = decode_labels(encoding_mapping, y_train)
     return dict(
-        model=model,
+        model=OutputItem(output_type=OutputType.JOBLIB_ARTIFACT, value=model),
         model_evaluation_df=model_evaluation_df,
         X_train_df=X_train,
         X_test_df=X_test,
@@ -409,7 +410,7 @@ def svm(
     y_test = decode_labels(encoding_mapping, y_test)
     y_train = decode_labels(encoding_mapping, y_train)
     return dict(
-        model=model,
+        model=OutputItem(output_type=OutputType.JOBLIB_ARTIFACT, value=model),
         model_evaluation_df=model_evaluation_df,
         X_train_df=X_train,
         X_test_df=X_test,

--- a/backend/protzilla/data_analysis/clustering.py
+++ b/backend/protzilla/data_analysis/clustering.py
@@ -12,6 +12,7 @@ from backend.protzilla.data_analysis.classification_helper import (
     evaluate_clustering_with_scoring,
     perform_grid_search_cv,
 )
+from backend.protzilla.steps import OutputItem, OutputType
 from backend.protzilla.utilities.transform_dfs import (
     is_long_format,
     long_to_wide,
@@ -131,7 +132,7 @@ def k_means(
             .reset_index()
         )
         return dict(
-            model=model,
+            model=OutputItem(output_type=OutputType.JOBLIB_ARTIFACT, value=model),
             model_evaluation_df=model_evaluation_df,
             cluster_labels_df=cluster_labels_df,
             cluster_centers_df=cluster_centers_df,
@@ -267,7 +268,7 @@ def expectation_maximisation(
     )
     cluster_labels_probabilities_df.insert(0, "Sample", protein_df_wide.index)
     return dict(
-        model=model,
+        model=OutputItem(output_type=OutputType.JOBLIB_ARTIFACT, value=model),
         model_evaluation_df=model_evaluation_df,
         cluster_labels_df=cluster_labels_df,
         cluster_labels_probabilities_df=cluster_labels_probabilities_df,
@@ -360,7 +361,7 @@ def hierarchical_agglomerative_clustering(
         {"Sample": protein_df_wide.index, "Cluster Labels": model.labels_}
     )
     return dict(
-        model=model,
+        model=OutputItem(output_type=OutputType.JOBLIB_ARTIFACT, value=model),
         model_evaluation_df=model_evaluation_df,
         cluster_labels_df=cluster_labels_df,
     )

--- a/backend/protzilla/disk_operator.py
+++ b/backend/protzilla/disk_operator.py
@@ -117,7 +117,7 @@ class ArtifactOperator:
         with ErrorHandler():
             logger.info(f"Writing artifact to {file_path}")
             file_path.parent.mkdir(parents=True, exist_ok=True)
-            joblib.dump(artifact, file_path)
+            joblib.dump(artifact, file_path, compress=("gzip", 3))
 
 
 RUN_FILE = "run.yaml"
@@ -293,7 +293,7 @@ class DiskOperator:
                     logger.warning(f"Deleting dataframe {file}")
                     file.unlink()
 
-    def clean_artifacts_dir(self, steps: StepManager) -> None:
+    def clean_artifact_dir(self, steps: StepManager) -> None:
         with ErrorHandler():
             if not self.artifact_dir.exists():
                 return
@@ -419,7 +419,8 @@ class DiskOperator:
                         )
                     case OutputType.JOBLIB_ARTIFACT:
                         file_path = (
-                            self.artifact_dir / f"{step.instance_identifier}_{key}.csv"
+                            self.artifact_dir
+                            / f"{step.instance_identifier}_{key}.joblib.gz"
                         )
                         # Only dump if outdated version
                         if self._dump_is_outdated(step, "output"):
@@ -511,16 +512,6 @@ def sanitize_inputs(inputs: dict) -> dict:
             continue
         if utilities.check_is_path(value):
             continue
-        if key == DataKey.PEPTIDE_DF:
-            continue
-        try:
-            yaml.safe_dump(value)
-            sanitized[key] = value
-        except Exception:
-            # not yaml serialisable -> ignore it to prevent errors
-            logger.warning(
-                f"Dropping non-YAML-serializable input {key} of type {type(value)}"
-            )
-            continue
+        sanitized[key] = value
 
     return sanitized

--- a/backend/protzilla/disk_operator.py
+++ b/backend/protzilla/disk_operator.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pandas as pd
 import yaml
+import joblib
 from plotly.io import read_json, write_json
 
 from backend.protzilla.constants.data_types import DataKey
@@ -103,6 +104,22 @@ class DataFrameOperator:
             dataframe.to_csv(file_path, index=False)
 
 
+# for all non serializable data types
+class ArtifactOperator:
+    @staticmethod
+    def read(file_path: Path):
+        with ErrorHandler():
+            logger.info(f"Reading artifact from {file_path}")
+            return joblib.load(file_path)
+
+    @staticmethod
+    def write(file_path: Path, artifact):
+        with ErrorHandler():
+            logger.info(f"Writing artifact to {file_path}")
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            joblib.dump(artifact, file_path)
+
+
 RUN_FILE = "run.yaml"
 
 
@@ -131,6 +148,7 @@ class DiskOperator:
         self.workflow_name = workflow_name
         self.yaml_operator = YamlOperator()
         self.dataframe_operator = DataFrameOperator()
+        self.artifact_operator = ArtifactOperator()
 
     def read_run(self, file: Path | None = None) -> StepManager:
         with ErrorHandler():
@@ -275,6 +293,17 @@ class DiskOperator:
                     logger.warning(f"Deleting dataframe {file}")
                     file.unlink()
 
+    def clean_artifacts_dir(self, steps: StepManager) -> None:
+        with ErrorHandler():
+            if not self.artifact_dir.exists():
+                return
+            for file in self.artifact_dir.iterdir():
+                if file.is_dir():
+                    continue
+                if not self.check_file_validity(file, steps):
+                    logger.warning(f"Deleting artifact {file}")
+                    file.unlink()
+
     def clear_upload_dir(self) -> None:
         # TODO in general our way of handling file uploads is kind of non-straightforward, maybe we should switch
         # to directly using the FileUpload provided by Django instead of the work-around with the path of the upload as a str
@@ -353,7 +382,12 @@ class DiskOperator:
                             output_type=OutputType.DATAFRAME,
                             value=self.dataframe_operator.read(self.run_dir / path),
                         )
-
+                    case OutputType.JOBLIB_ARTIFACT:
+                        path = Path(str(item.value))
+                        step_output[key] = OutputItem(
+                            output_type=OutputType.JOBLIB_ARTIFACT,
+                            value=self.artifact_operator.read(self.run_dir / path),
+                        )
                     case _:
                         step_output[key] = item
 
@@ -381,6 +415,17 @@ class DiskOperator:
                             self.dataframe_operator.write(file_path, item.value)
                         output_data[key] = OutputItem(
                             output_type=OutputType.DATAFRAME,
+                            value=str(file_path.relative_to(self.run_dir)),
+                        )
+                    case OutputType.JOBLIB_ARTIFACT:
+                        file_path = (
+                            self.artifact_dir / f"{step.instance_identifier}_{key}.csv"
+                        )
+                        # Only dump if outdated version
+                        if self._dump_is_outdated(step, "output"):
+                            self.artifact_operator.write(file_path, item.value)
+                        output_data[key] = OutputItem(
+                            output_type=OutputType.JOBLIB_ARTIFACT,
                             value=str(file_path.relative_to(self.run_dir)),
                         )
                     case _:
@@ -444,6 +489,10 @@ class DiskOperator:
         return self.run_dir / "dataframes"
 
     @property
+    def artifact_dir(self) -> Path:
+        return self.run_dir / "artifacts"
+
+    @property
     def plot_dir(self) -> Path:
         return self.run_dir / "plots"
 
@@ -455,10 +504,23 @@ def sanitize_inputs(inputs: dict) -> dict:
     :param inputs: The inputs to sanitize
     :return: The sanitized inputs
     """
-    return {
-        key: value
-        for key, value in inputs.items()
-        if type(value) != pd.DataFrame
-        and not utilities.check_is_path(value)
-        and key != DataKey.PEPTIDE_DF
-    }
+    sanitized = {}
+
+    for key, value in inputs.items():
+        if isinstance(value, pd.DataFrame):
+            continue
+        if utilities.check_is_path(value):
+            continue
+        if key == DataKey.PEPTIDE_DF:
+            continue
+        try:
+            yaml.safe_dump(value)
+            sanitized[key] = value
+        except Exception:
+            # not yaml serialisable -> ignore it to prevent errors
+            logger.warning(
+                f"Dropping non-YAML-serializable input {key} of type {type(value)}"
+            )
+            continue
+
+    return sanitized

--- a/backend/protzilla/steps.py
+++ b/backend/protzilla/steps.py
@@ -466,6 +466,8 @@ class OutputType(StrEnum):
     MESSAGES = "messages"
     FLOAT = "float"
     INT = "int"
+    # for every data type that is not yaml serializable
+    JOBLIB_ARTIFACT = "joblib_artifact"
 
 
 class OutputItem(yaml.YAMLObject):

--- a/backend/tests/protzilla/data_analysis/test_classification.py
+++ b/backend/tests/protzilla/data_analysis/test_classification.py
@@ -129,13 +129,14 @@ def test_random_forest_score(random_forest_out, validation_strategy, model_selec
 
 
 def test_model_evaluation_plots(show_figures, random_forest_out, helpers):
+    model = random_forest_out["model"].value
     recall_curve_base64 = precision_recall_curve_plot(
-        random_forest_out["model"],
+        model,
         random_forest_out["X_test_df"],
         random_forest_out["y_test_df"],
     )
     roc_curve_base64 = roc_curve_plot(
-        random_forest_out["model"],
+        model,
         random_forest_out["X_test_df"],
         random_forest_out["y_test_df"],
     )
@@ -147,7 +148,7 @@ def test_model_evaluation_plots(show_figures, random_forest_out, helpers):
 
 def test_evaluate_classification_model(show_figures, random_forest_out):
     evaluation_out = evaluate_classification_model(
-        random_forest_out["model"],
+        random_forest_out["model"].value,
         random_forest_out["X_test_df"],
         random_forest_out["y_test_df"],
         ["accuracy", "precision", "recall", "matthews_corrcoef"],

--- a/backend/tests/protzilla/data_analysis/test_clustering.py
+++ b/backend/tests/protzilla/data_analysis/test_clustering.py
@@ -100,7 +100,7 @@ def test_k_means(clustering_df, meta_df):
         check_dtype=False,
     )
 
-    np.array_equal(centroids_assertion, current_out["model"].cluster_centers_)
+    np.array_equal(centroids_assertion, current_out["model"].value.cluster_centers_)
 
 
 def test_k_means_nan_handling(df_with_nan, meta_df):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Django==5.2.8
 django-cors-headers==4.9.0
 gseapy==1.1.10
 isort==7.0.0
+joblib==1.2.0
 kaleido~=0.1
 networkx==3.5
 numba==0.62.1


### PR DESCRIPTION
## Description
We can now read and write non yaml serializable data such as sklearn models on disk.

## Changes
Most changes are in the disk operator.

## Testing
Use any of the clustering or classification steps and check whether they are calculated and protzilla does not crash when reloading the page or when switching to another step and back. (Make sure to build with docker because we have a new library)

## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [ ] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
