### PR TITLE
88 bug nextcalculate buttons not updating

### DIFF
--- a/frontend/src/components/core/shared/input-fields/number-input-field/number-input-field.tsx
+++ b/frontend/src/components/core/shared/input-fields/number-input-field/number-input-field.tsx
@@ -70,6 +70,8 @@ export const NumberInputField: React.FC<NumberInputFieldProps> = ({
   const hasMin = typeof min === "number";
   const hasMax = typeof max === "number";
 
+  const wasThereInputAfterHandleBlurRef = useRef(false);
+
   const handleChange = (e: { target: { value: string } }) => {
     const raw = e.target.value;
 
@@ -77,9 +79,17 @@ export const NumberInputField: React.FC<NumberInputFieldProps> = ({
     if (isInteger && raw.includes(".")) return;
 
     setDisplayValue(raw);
+    if (!wasThereInputAfterHandleBlurRef.current) {
+      const num = isInteger ? parseInt(raw, 10) : parseFloat(raw);
+      if (!isNaN(num)) {
+        wasThereInputAfterHandleBlurRef.current = true;
+        onChange(num);
+      }
+    }
   };
 
   const handleBlur = () => {
+    wasThereInputAfterHandleBlurRef.current = false;
     if (displayValue === "" || displayValue === "-") {
       setDisplayValue(String(Math.max(0, min ?? 0)));
       return;

--- a/frontend/src/components/core/shared/input-fields/text-input-field/text-input-field.tsx
+++ b/frontend/src/components/core/shared/input-fields/text-input-field/text-input-field.tsx
@@ -1,5 +1,5 @@
 import { color, fontSize, size, spacing } from "@protzilla/theme";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { styled } from "styled-components";
 
 import { TextInputFieldProps } from "./text-input-field.props";
@@ -30,7 +30,21 @@ export const TextInputField: React.FC<TextInputFieldProps> = ({
     //eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const wasThereInputAfterHandleBlurRef = useRef(false);
+
   const handleChange = (value: string) => {
+    if (characterLimit >= 0 && value.length > characterLimit) {
+      return;
+    }
+    setValue(value);
+    if (!wasThereInputAfterHandleBlurRef.current) {
+      wasThereInputAfterHandleBlurRef.current = true;
+      onChange(value);
+    }
+  };
+
+  const handleBlur = () => {
+    wasThereInputAfterHandleBlurRef.current = false;
     if (characterLimit >= 0 && value.length > characterLimit) {
       return;
     }
@@ -55,6 +69,13 @@ export const TextInputField: React.FC<TextInputFieldProps> = ({
         placeholder={placeholder}
         onChange={(e) => {
           handleChange(e.target.value);
+        }}
+        onBlur={handleBlur}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            handleBlur();
+            (e.target as HTMLInputElement).blur();
+          }
         }}
         $isSmall={props.isSmall ?? false}
         {...props}


### PR DESCRIPTION
## Description
fixes #88
See issue description. Additionally, fixed the issue where not all key strokes in text fields were registered when you typed too fast.

## Changes
Added the wasThereInputAfterHandleBlurRef-variable so that we call onChange the first time we enter something new (-> button will get updated), but won't call onChange afterwards (-> we are still entering in the same number field and the button was already updated).


## Testing
If you have the following steps you can test the number field in the protein filter step and the text field in the clustergram step. Enter something, calculate and enter something else without hiting enter/clicking somewhere else and watch how the next button switches to the calculate button. Also, try to type really fast and see how all your keystrokes are being displayed as expected. Make sure that the value you entered was used in the result.
<img width="490" height="267" alt="grafik" src="https://github.com/user-attachments/assets/1608070b-1cf5-419f-93d4-55f9d61986e7" />

## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [ ] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
