### PR TITLE
Fixes de-serialization issues regarding paths when saving/loading runs

### DIFF
--- a/backend/protzilla/disk_operator.py
+++ b/backend/protzilla/disk_operator.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import traceback
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PosixPath, WindowsPath
 
 import pandas as pd
 import yaml
@@ -67,6 +67,20 @@ def output_type_constructor(loader, node):
 
 yaml.add_representer(OutputType, output_type_representer)
 yaml.add_constructor("!OutputType", output_type_constructor)
+
+
+def path_representer(dumper, path):
+    return dumper.represent_scalar("!file_path", path.as_posix())
+
+
+def path_constructor(loader, node):
+    value = loader.construct_scalar(node)
+    return Path(value)
+
+
+yaml.add_representer(PosixPath, path_representer)
+yaml.add_representer(WindowsPath, path_representer)
+yaml.add_constructor("!file_path", path_constructor)
 
 
 class YamlOperator:

--- a/backend/tests/protzilla/test_disk_operator.py
+++ b/backend/tests/protzilla/test_disk_operator.py
@@ -18,11 +18,11 @@ def test_yaml_operator_path_handling(tmp_output_dir):
     # explicitly try to create a WindowsPath on Linux/Mac or a PosixPath on Windows.
     yaml_operator = YamlOperator()
     dummy_path = "/backend/user_data/runs/dummy/run.yaml"
-    data_dict = {
-        "file_path": pathlib.Path(dummy_path)
-    }
+    data_dict = {"file_path": pathlib.Path(dummy_path)}
     out_file_path = tmp_output_dir / "yaml_test.yaml"
     yaml_operator.write(out_file_path, data_dict)
     yaml_file_contents = yaml_operator.read(out_file_path)
     assert yaml_file_contents["file_path"] == pathlib.Path(dummy_path)
-    assert str(yaml_file_contents["file_path"]) == str(pathlib.PureWindowsPath(dummy_path))
+    assert str(yaml_file_contents["file_path"]) == str(
+        pathlib.PureWindowsPath(dummy_path)
+    )

--- a/backend/tests/protzilla/test_disk_operator.py
+++ b/backend/tests/protzilla/test_disk_operator.py
@@ -1,0 +1,28 @@
+import pathlib
+
+import pytest
+
+from protzilla.disk_operator import YamlOperator
+
+
+@pytest.fixture()
+def tmp_output_dir(tmp_path_factory):
+    test_tmp_data_dir = pathlib.Path("yaml_outputs/")
+    tmp_path = tmp_path_factory.mktemp(str(test_tmp_data_dir))
+    return tmp_path
+
+
+def test_yaml_operator_path_handling(tmp_output_dir):
+    # This test will (de)serialize a PosixPath on Linux/Mac and a WindowsPath on Windows. Unfortunately, it does not
+    # seem to be possible to test both (de)serializations on a single platform, as pathlib will return an error if you
+    # explicitly try to create a WindowsPath on Linux/Mac or a PosixPath on Windows.
+    yaml_operator = YamlOperator()
+    dummy_path = "/backend/user_data/runs/dummy/run.yaml"
+    data_dict = {
+        "file_path": pathlib.Path(dummy_path)
+    }
+    out_file_path = tmp_output_dir / "yaml_test.yaml"
+    yaml_operator.write(out_file_path, data_dict)
+    yaml_file_contents = yaml_operator.read(out_file_path)
+    assert yaml_file_contents["file_path"] == pathlib.Path(dummy_path)
+    assert str(yaml_file_contents["file_path"]) == str(pathlib.PureWindowsPath(dummy_path))

--- a/backend/tests/protzilla/test_disk_operator.py
+++ b/backend/tests/protzilla/test_disk_operator.py
@@ -23,6 +23,3 @@ def test_yaml_operator_path_handling(tmp_output_dir):
     yaml_operator.write(out_file_path, data_dict)
     yaml_file_contents = yaml_operator.read(out_file_path)
     assert yaml_file_contents["file_path"] == pathlib.Path(dummy_path)
-    assert str(yaml_file_contents["file_path"]) == str(
-        pathlib.PureWindowsPath(dummy_path)
-    )


### PR DESCRIPTION
## Description

Ensures that YAML serialization and deserialization of file paths (both `PosixPath` and `WindowsPath`) are handled correctly. Otherwise, some runs cannot be loaded again.
Also adds a test for this.

## Testing

**Would be cool if so. with Windows could actually test this.**

Create a run that has a step that needs a file (e.g., any of the ptm visualization plots) and upload a file. Try to reload the run from the start page, and it should work.

## PR checklist
**Development**
- [X] If necessary, I have updated the documentation (README, docstrings, etc.)
- [X] If necessary, I have created / updated tests.
 
**Mergeability**
- [X] main-branch has been merged into local branch to resolve conflicts
- [X] The tests and linter have passed AFTER local merge
- [X] The backend code has been formatted with `black`
- [X] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [X] I have self-reviewed my code.
- [x] At least one other developer reviewed and approved the changes
