### PR TITLE
Changes output of example dataset import to psm_df

### DIFF
--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -405,7 +405,7 @@ class ExampleDatasetImport(ImportingStep):
         self.output_keys = self.output_keys = (
             [
                 DataKey.METADATA_DF,
-                DataKey.PEPTIDE_DF,
+                DataKey.PSM_DF,
                 DataKey.PROTEIN_DF,
             ]
             if import_peptide_data_field.value


### PR DESCRIPTION
## Description

Changes the output of the example dataset import from peptide_df to psm_df. Was an oversight in a previous attempt to separate the namings for peptides and evidence dataframes.

## Testing

Create a run with the example dataset import and verify that the output is a psm_df (and works with steps that require psm_df, such as the ptm visualizations)
