### PR TITLE
266 file picker in forms

### DIFF
--- a/backend/protzilla/form.py
+++ b/backend/protzilla/form.py
@@ -155,6 +155,7 @@ class FileInput(_baseField):
     value: str | None = None
     type: str = "file"
     filedata: str = ""
+    accept: str | None = None
 
 
 @dataclass

--- a/backend/protzilla/methods/data_analysis.py
+++ b/backend/protzilla/methods/data_analysis.py
@@ -2267,12 +2267,12 @@ class _PTMVisualizationStep(DataAnalysisPlotStep, ABC):
                 hasStepButtons=False,
             ),
             FileInput(
-                name="fasta_file_path",
-                label="FASTA file",
+                name="fasta_file_path", label="FASTA file", accept=".fasta,.fa,.faa"
             ),
             FileInput(
                 name="regions_file_path",
                 label="Metadata used to define regions",
+                accept=".csv",
             ),
             InfoField(
                 label="The file for regions should be a CSV file with the following columns: name, region_end, "

--- a/backend/protzilla/methods/data_integration.py
+++ b/backend/protzilla/methods/data_integration.py
@@ -172,6 +172,7 @@ class EnrichmentAnalysisGOAnalysisWithString(EnrichmentAnalysisGOStep):
                 FileInput(
                     name="background_path",
                     label="Background set (no upload = entire proteome), UniProt IDs (one per line, txt or csv)",
+                    accept=".txt,.csv",
                 ),
             ],
         )
@@ -245,6 +246,7 @@ class EnrichmentAnalysisGOAnalysisWithEnrichr(EnrichmentAnalysisGOStep):
                     ".txt (one set per line): SetName followed by tab-separated list of proteins\n"
                     ".csv (one set per line): SetName, Gene1, Gene2, ...\n"
                     r".json: {SetName: [Gene1, Gene2, ...], SetName2: [Gene2, Gene3,...]})",
+                    accept=".gmt,.txt,.csv,.json",
                 ),
                 DropdownField(
                     name="gene_sets_enrichr",
@@ -259,6 +261,7 @@ class EnrichmentAnalysisGOAnalysisWithEnrichr(EnrichmentAnalysisGOStep):
                 FileInput(
                     name="background_path",
                     label="Background set with uppercase gene symbols (one gene per line, csv or txt)",
+                    accept=".txt,.csv",
                 ),
                 NumberField(
                     name="background_number",
@@ -372,6 +375,7 @@ class EnrichmentAnalysisGOAnalysisOffline(EnrichmentAnalysisGOStep):
                     "followed by tab-separated list of proteins | .csv (one set per line): "
                     "SetName, Gene1, Gene2, ... | .json: {SetName: [Gene1, Gene2, ...], "
                     "SetName2: [Gene2, Gene3, ...]})",
+                    accept=".gmt,.txt,.csv,.json",
                 ),
                 DropdownField(
                     name="direction",
@@ -388,6 +392,7 @@ class EnrichmentAnalysisGOAnalysisOffline(EnrichmentAnalysisGOStep):
                 FileInput(
                     name="background_path",
                     label="Background set with uppercase gene symbols (one gene per line, csv or txt)",
+                    accept=".txt,.csv",
                 ),
                 NumberField(
                     name="background_number",
@@ -460,6 +465,7 @@ class EnrichmentAnalysisWithGSEA(EnrichmentAnalysisStep):
                     "followed by tab-separated list of proteins | .csv (one set per line): "
                     "SetName, Gene1, Gene2, ... | .json: {SetName: [Gene1, Gene2, ...], "
                     "SetName2: [Gene2, Gene3, ...]})",
+                    accept=".gmt,.txt,.csv,.json",
                 ),
                 DropdownField(
                     name="gene_sets_enrichr",
@@ -607,6 +613,7 @@ class EnrichmentAnalysisWithPrerankedGSEA(EnrichmentAnalysisStep):
                     "followed by tab-separated list of proteins | .csv (one set per line): "
                     "SetName, Gene1, Gene2, ... | .json: {SetName: [Gene1, Gene2, ...], "
                     "SetName2: [Gene2, Gene3, ...]})",
+                    accept=".gmt,.txt,.csv,.json",
                 ),
                 DropdownField(
                     name="gene_sets_enrichr",

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -60,7 +60,12 @@ class ArbitraryCSVImport(ImportingStep):
         return Form(
             label="Arbitrary CSV Import",
             input_fields=[
-                FileInput(name="file_path", label="CSV file", value=None, accept=".csv")
+                FileInput(
+                    name="file_path",
+                    label="CSV file",
+                    value=None,
+                    accept=".csv",
+                )
             ],
         )
 
@@ -87,7 +92,7 @@ class MaxQuantImport(ImportingStep):
                     name="file_path",
                     label="MaxQuant intensities file (proteinGroups.txt)",
                     value=None,
-                    accept=".txt",
+                    accept=".txt,.tsv,.csv",
                 ),
                 DropdownField(
                     name="intensity_name",
@@ -132,7 +137,7 @@ class DiannImport(ImportingStep):
                     name="file_path",
                     label="DIA-NN intensities file (*.pg_matrix.tsv)",
                     value=None,
-                    accept=".tsv",
+                    accept=".txt,.tsv,.csv",
                 ),
                 CheckboxField(
                     name="map_to_uniprot",
@@ -167,7 +172,7 @@ class MsFraggerImport(ImportingStep):
                 FileInput(
                     name="file_path",
                     label="MSFragger intensities file (combined_proteins.tsv)",
-                    accept=".tsv",
+                    accept=".txt,.tsv,.csv",
                 ),
                 DropdownField(
                     name="intensity_name",
@@ -202,7 +207,11 @@ class MetadataImport(MetadataImportingStep):
         return Form(
             label="Metadata Import",
             input_fields=[
-                FileInput(name="file_path", label="Metadata file", accept=".csv"),
+                FileInput(
+                    name="file_path",
+                    label="Metadata file",
+                    accept=".csv,.xlsx,.psv,.tsv",
+                ),
                 DropdownField(
                     name="feature_orientation",
                     label="Feature orientation",
@@ -290,7 +299,11 @@ class PeptideImport(ImportingStep):
         return Form(
             label="MaxQuant Peptide Import",
             input_fields=[
-                FileInput(name="file_path", label="Peptide file", accept=".txt"),
+                FileInput(
+                    name="file_path",
+                    label="Peptide file",
+                    accept=".txt,.tsv,.csv",
+                ),
                 DropdownField(
                     name="intensity_name",
                     label="Intensity parameter",
@@ -319,7 +332,11 @@ class EvidenceImport(ImportingStep):
         return Form(
             label="MaxQuant Evidence Import",
             input_fields=[
-                FileInput(name="file_path", label="Evidence file", accept=".txt"),
+                FileInput(
+                    name="file_path",
+                    label="Evidence file",
+                    accept=".txt,.tsv,.csv",
+                ),
                 DropdownField(
                     name="intensity_name",
                     label="Intensity parameter",
@@ -350,7 +367,11 @@ class FastaImport(ImportingStep):
         return Form(
             label="Fasta Protein Sequence Import",
             input_fields=[
-                FileInput(name="file_path", label="Fasta file", accept=".fasta"),
+                FileInput(
+                    name="file_path",
+                    label="Fasta file",
+                    accept=".fasta,.fa,.faa",
+                ),
             ],
         )
 

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -60,11 +60,7 @@ class ArbitraryCSVImport(ImportingStep):
         return Form(
             label="Arbitrary CSV Import",
             input_fields=[
-                FileInput(
-                    name="file_path",
-                    label="CSV file",
-                    value=None,
-                )
+                FileInput(name="file_path", label="CSV file", value=None, accept=".csv")
             ],
         )
 
@@ -91,6 +87,7 @@ class MaxQuantImport(ImportingStep):
                     name="file_path",
                     label="MaxQuant intensities file (proteinGroups.txt)",
                     value=None,
+                    accept=".txt",
                 ),
                 DropdownField(
                     name="intensity_name",
@@ -135,6 +132,7 @@ class DiannImport(ImportingStep):
                     name="file_path",
                     label="DIA-NN intensities file (*.pg_matrix.tsv)",
                     value=None,
+                    accept=".tsv",
                 ),
                 CheckboxField(
                     name="map_to_uniprot",
@@ -169,6 +167,7 @@ class MsFraggerImport(ImportingStep):
                 FileInput(
                     name="file_path",
                     label="MSFragger intensities file (combined_proteins.tsv)",
+                    accept=".tsv",
                 ),
                 DropdownField(
                     name="intensity_name",
@@ -203,10 +202,7 @@ class MetadataImport(MetadataImportingStep):
         return Form(
             label="Metadata Import",
             input_fields=[
-                FileInput(
-                    name="file_path",
-                    label="Metadata file",
-                ),
+                FileInput(name="file_path", label="Metadata file", accept=".csv"),
                 DropdownField(
                     name="feature_orientation",
                     label="Feature orientation",
@@ -294,10 +290,7 @@ class PeptideImport(ImportingStep):
         return Form(
             label="MaxQuant Peptide Import",
             input_fields=[
-                FileInput(
-                    name="file_path",
-                    label="Peptide file",
-                ),
+                FileInput(name="file_path", label="Peptide file", accept=".txt"),
                 DropdownField(
                     name="intensity_name",
                     label="Intensity parameter",
@@ -326,10 +319,7 @@ class EvidenceImport(ImportingStep):
         return Form(
             label="MaxQuant Evidence Import",
             input_fields=[
-                FileInput(
-                    name="file_path",
-                    label="Evidence file",
-                ),
+                FileInput(name="file_path", label="Evidence file", accept=".txt"),
                 DropdownField(
                     name="intensity_name",
                     label="Intensity parameter",
@@ -360,10 +350,7 @@ class FastaImport(ImportingStep):
         return Form(
             label="Fasta Protein Sequence Import",
             input_fields=[
-                FileInput(
-                    name="file_path",
-                    label="Fasta file",
-                ),
+                FileInput(name="file_path", label="Fasta file", accept=".fasta"),
             ],
         )
 

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -92,7 +92,7 @@ class MaxQuantImport(ImportingStep):
                     name="file_path",
                     label="MaxQuant intensities file (proteinGroups.txt)",
                     value=None,
-                    accept=".txt,.tsv,.csv",
+                    accept=".txt",
                 ),
                 DropdownField(
                     name="intensity_name",
@@ -137,7 +137,7 @@ class DiannImport(ImportingStep):
                     name="file_path",
                     label="DIA-NN intensities file (*.pg_matrix.tsv)",
                     value=None,
-                    accept=".txt,.tsv,.csv",
+                    accept="txt,.tsv",
                 ),
                 CheckboxField(
                     name="map_to_uniprot",
@@ -172,7 +172,7 @@ class MsFraggerImport(ImportingStep):
                 FileInput(
                     name="file_path",
                     label="MSFragger intensities file (combined_proteins.tsv)",
-                    accept=".txt,.tsv,.csv",
+                    accept=".txt,.tsv",
                 ),
                 DropdownField(
                     name="intensity_name",
@@ -302,7 +302,7 @@ class PeptideImport(ImportingStep):
                 FileInput(
                     name="file_path",
                     label="Peptide file",
-                    accept=".txt,.tsv,.csv",
+                    accept=".txt",
                 ),
                 DropdownField(
                     name="intensity_name",
@@ -335,7 +335,7 @@ class EvidenceImport(ImportingStep):
                 FileInput(
                     name="file_path",
                     label="Evidence file",
-                    accept=".txt,.tsv,.csv",
+                    accept=".txt",
                 ),
                 DropdownField(
                     name="intensity_name",


### PR DESCRIPTION
## Description
fixes #266 
Before the user could choose any file for the file import although we had a file picker implemented for the frontend but did not use it in the backend. The user should now only be able to import the file types we want them to. (Well not really, there is a way around it - but at least it is visible which file types are expected.)

## Changes
One little line in forms.py and everywhere where we use the File Import Field.

## Testing
Create a run and check out any step that requires you to upload a file.

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
