### PR TITLE
316 rename metadata df of structures

### DIFF
--- a/backend/protzilla/constants/data_types.py
+++ b/backend/protzilla/constants/data_types.py
@@ -11,6 +11,7 @@ class DataKey(StrEnum):
     PEPTIDE_DF = "peptide_df"
     PSM_DF = "psm_df"  # psm = peptide spectrum match
     METADATA_DF = "metadata_df"
+    STRUCTURE_METADATA_DF = "structure_metadata_df"
     FASTA_DF = "fasta_df"
     SIGNIFICANT_PROTEINS_DF = "significant_proteins_df"
     PTM_DF = "ptm_df"

--- a/backend/protzilla/data_analysis/crosslinking_validation.py
+++ b/backend/protzilla/data_analysis/crosslinking_validation.py
@@ -256,11 +256,11 @@ def add_protein_crosslink_positions_to_df(
     return crosslinking_df, messages
 
 
-def _get_structures_to_validate(metadata_df: pd.DataFrame) -> list[str]:
-    if "uniprot_accession" in metadata_df.columns:
-        return metadata_df["uniprot_accession"].tolist()
-    elif "uniprot_ids" in metadata_df.columns:
-        value = metadata_df["uniprot_ids"].iloc[0]
+def _get_structures_to_validate(structure_metadata_df: pd.DataFrame) -> list[str]:
+    if "uniprot_accession" in structure_metadata_df.columns:
+        return structure_metadata_df["uniprot_accession"].tolist()
+    elif "uniprot_ids" in structure_metadata_df.columns:
+        value = structure_metadata_df["uniprot_ids"].iloc[0]
         if isinstance(value, str):
             value = ast.literal_eval(value)
         return value
@@ -270,7 +270,7 @@ def _get_structures_to_validate(metadata_df: pd.DataFrame) -> list[str]:
 
 def validate_with_angstrom_deviation(
     crosslinking_df: pd.DataFrame,
-    metadata_df: pd.DataFrame,
+    structure_metadata_df: pd.DataFrame,
     crosslinker_information: dict[str, list[float]],
     cif_df: pd.DataFrame,
     amino_acid_sequences_df: pd.DataFrame,
@@ -282,7 +282,7 @@ def validate_with_angstrom_deviation(
     and more than (cross-linker length - the lower allowed deviation). If one of the bounds is zero only the other bound will be applied.
 
     :param crosslinking_df: DataFrame containing cross-linking data.
-    :param metadata_df: DataFrame containing metadata
+    :param structure_metadata_df: DataFrame containing metadata
     :param crosslinker_information: Contains for each Crosslinker:
                    - length_of_<Crosslinker>: float
                    - lower_accepted_deviation_for_<Crosslinker>: float
@@ -295,7 +295,7 @@ def validate_with_angstrom_deviation(
     :raises KeyError: If a required crosslinker field is missing in crosslinker_information.
     :raises ValueError: If peptide sequences cannot be matched to the protein sequence.
     """
-    structures_to_validate = _get_structures_to_validate(metadata_df)
+    structures_to_validate = _get_structures_to_validate(structure_metadata_df)
     all_crosslinks_df = crosslinking_df.copy()
     is_multimer = len(structures_to_validate) > 1
     if not is_multimer:
@@ -399,7 +399,7 @@ def validate_with_angstrom_deviation(
 
 def diagrams_of_crosslinking_validation_data(
     crosslinking_df: pd.DataFrame,
-    metadata_df: pd.DataFrame,
+    structure_metadata_df: pd.DataFrame,
     crosslinker_information: dict[str, list[float]],
     cif_df: pd.DataFrame,
     amino_acid_sequences_df: pd.DataFrame,
@@ -421,7 +421,7 @@ def diagrams_of_crosslinking_validation_data(
 
     :param crosslinking_df: DataFrame containing cross-linking data, including AlphaFold-predicted
                             distances, crosslinker identifiers, and validation results.
-    :param metadata_df: Dataframe containing metadata.
+    :param structure_metadata_df: Dataframe containing metadata.
     :param crosslinker_information: Contains for each Crosslinker:
                    - length_of_<Crosslinker>: float
                    - lower_accepted_deviation_for_<Crosslinker>: float
@@ -433,10 +433,10 @@ def diagrams_of_crosslinking_validation_data(
              bar plot summarizing valid and invalid cross-links across all crosslinkers.
     :raises KeyError: If a required crosslinker entry is missing in crosslinker_information.
     """
-    structures_to_validate = _get_structures_to_validate(metadata_df)
+    structures_to_validate = _get_structures_to_validate(structure_metadata_df)
     validated_df = validate_with_angstrom_deviation(
         crosslinking_df,
-        metadata_df,
+        structure_metadata_df,
         crosslinker_information,
         cif_df,
         amino_acid_sequences_df,

--- a/backend/protzilla/importing/alphafold_protein_structure_load.py
+++ b/backend/protzilla/importing/alphafold_protein_structure_load.py
@@ -26,8 +26,8 @@ def get_monomer_metadata_df() -> pd.DataFrame:
     Returns all data from alphafold_monomer_metadata.csv in form of a dataframe. If no such csv exist, it returns
     a dataframe with the corresponding keys but no values and creates a csv with the expected column names.
     """
-    metadata_csv = paths.AF_MONOMER_METADATA_CSV_PATH
-    if not metadata_csv.exists():
+    monomer_metadata_csv = paths.AF_MONOMER_METADATA_CSV_PATH
+    if not monomer_metadata_csv.exists():
         metadata_df = pd.DataFrame(
             columns=[
                 "entry_id",
@@ -37,10 +37,10 @@ def get_monomer_metadata_df() -> pd.DataFrame:
                 "model_used",
             ]
         )
-        metadata_csv.parent.mkdir(parents=True, exist_ok=True)
-        metadata_df.to_csv(metadata_csv, index=False)
+        monomer_metadata_csv.parent.mkdir(parents=True, exist_ok=True)
+        metadata_df.to_csv(monomer_metadata_csv, index=False)
         return metadata_df
-    return pd.read_csv(metadata_csv, dtype=str)
+    return pd.read_csv(monomer_metadata_csv, dtype=str)
 
 
 def get_multimer_metadata_df() -> pd.DataFrame:
@@ -48,9 +48,9 @@ def get_multimer_metadata_df() -> pd.DataFrame:
     Returns all data from alphafold_multimer_metadata.csv in form of a dataframe. If no such csv exist, it returns
     a dataframe with the corresponding keys but no values and creates a csv with the expected column names.
     """
-    metadata_csv = paths.AF_MULTIMER_METADATA_CSV_PATH
+    multimer_metadata_csv = paths.AF_MULTIMER_METADATA_CSV_PATH
 
-    if not metadata_csv.exists():
+    if not multimer_metadata_csv.exists():
         metadata_df = pd.DataFrame(
             columns=[
                 "entry_id",
@@ -59,10 +59,10 @@ def get_multimer_metadata_df() -> pd.DataFrame:
                 "model_used",
             ]
         )
-        metadata_csv.parent.mkdir(parents=True, exist_ok=True)
-        metadata_df.to_csv(metadata_csv, index=False)
+        multimer_metadata_csv.parent.mkdir(parents=True, exist_ok=True)
+        metadata_df.to_csv(multimer_metadata_csv, index=False)
         return metadata_df
-    return pd.read_csv(metadata_csv, dtype=str)
+    return pd.read_csv(multimer_metadata_csv, dtype=str)
 
 
 def to_fasta(seq: str, header: str = "protein_sequence", width: int = 60) -> str:
@@ -244,7 +244,7 @@ def handle_alphafold_files(
     files_urls: dict[str, Any],
     uniprot: str,
     seq: str,
-    metadata_df: pd.DataFrame,
+    monomer_metadata_df: pd.DataFrame,
     entry_id: str,
     persist_upload: bool = False,
 ) -> dict[str, pd.DataFrame | None]:
@@ -258,10 +258,10 @@ def handle_alphafold_files(
     :param files_urls: Dictionary containing URLs for CIF, PAE, and pLDDT files
     :param uniprot: The UniProt ID of the protein
     :param seq: The protein sequence
-    :param metadata_df: DataFrame containing AlphaFold metadata
+    :param monomer_metadata_df: DataFrame containing AlphaFold monomer metadata
     :param entry_id: The entry_id (in the case of fetching from AF DB the same as uniprot id) (used for directory naming)
     :param persist_upload: If True, files are saved persistently; if False, only loaded into memory
-    :return: A dictionary containing DataFrames for metadata, CIF, PAE, pLDDT, sequence data or None values for
+    :return: A dictionary containing DataFrames for monomer metadata, CIF, PAE, pLDDT, sequence data or None values for
     failed loads and messages such as warnings
     """
     cif_df = pd.DataFrame()
@@ -284,7 +284,7 @@ def handle_alphafold_files(
                 entry_id=entry_id,
                 metadata_csv=paths.AF_MONOMER_METADATA_CSV_PATH,
                 existing_metadata_df=existing_metadata_df,
-                metadata_df=metadata_df,
+                metadata_df=monomer_metadata_df,
                 messages=messages,
             )
 
@@ -342,12 +342,12 @@ def fetch_alphafold_protein_structure(
     """
     Fetch AlphaFold protein structure data from the AlphaFold Database API.
 
-    Retrieves metadata and structure files (CIF, PAE, pLDDT) from the AlphaFold Database
+    Retrieves monomer metadata and structure files (CIF, PAE, pLDDT) from the AlphaFold Database
     for the given UniProt ID. Optionally persists the downloaded files to disk.
 
     :param uniprot_id: The UniProt ID of the protein
     :param persist_upload: If True, files are saved persistently; if False, only loaded into memory
-    :return: A dictionary containing DataFrames for metadata, CIF, PAE, pLDDT, and sequence data
+    :return: A dictionary containing DataFrames for monomer metadata, CIF, PAE, pLDDT, and sequence data
     :raises RuntimeError: If the API request fails or returns invalid data
     :raises ValueError: If no predictions are found for the given UniProt ID
     """
@@ -391,18 +391,18 @@ def fetch_alphafold_protein_structure(
             if isinstance(r.get(key), str) and r.get(key):
                 files_urls[key] = r[key]
 
-        metadata_df = pd.DataFrame([data])
+        monomer_metadata_df = pd.DataFrame([data])
 
         alpha_dfs = handle_alphafold_files(
             files_urls=files_urls,
             uniprot=uniprot_id,
             seq=seq_tmp,
-            metadata_df=metadata_df,
+            monomer_metadata_df=monomer_metadata_df,
             entry_id=uniprot_id,
             persist_upload=persist_upload,
         )
     df_dict = {
-        "metadata_df": metadata_df,
+        "structure_metadata_df": monomer_metadata_df,
         "cif_df": alpha_dfs["cif_df"],
         "pae_df": alpha_dfs["pae_df"],
         "plddt_df": alpha_dfs["plddt_df"],
@@ -617,12 +617,12 @@ def get_monomer_structure_dfs(entry_id: str) -> dict[str, Any]:
     Writes monomer structure data from disk of a specific entry ID into dataframes.
 
     :param entry_id: entry_id of the uploaded monomer structure
-    :return: A dictionary containing DataFrames for metadata, CIF, PAE, pLDDT, and sequence data
+    :return: A dictionary containing DataFrames for monomer metadata, CIF, PAE, pLDDT, and sequence data
     """
     messages: list[dict[str, str | int]] = []
     all_metadata_df = get_monomer_metadata_df()
 
-    metadata_df = check_and_get_metadata_df(
+    monomer_metadata_df = check_and_get_metadata_df(
         entry_id=entry_id,
         all_metadata_df=all_metadata_df,
         csv_file=paths.AF_MONOMER_METADATA_CSV_PATH,
@@ -683,7 +683,7 @@ def get_monomer_structure_dfs(entry_id: str) -> dict[str, Any]:
         raise RuntimeError(msg) from e
 
     df_dict = {
-        "metadata_df": metadata_df,
+        "structure_metadata_df": monomer_metadata_df,
         "cif_df": cif_df,
         "pae_df": pae_df,
         "plddt_df": plddt_df,
@@ -699,12 +699,12 @@ def get_multimer_structure_dfs(entry_id: str) -> dict[str, Any]:
     Writes multimer structure data from disk of a specific entry ID into dataframes.
 
     :param entry_id: entry_id of the uploaded monomer structure
-    :return: A dictionary containing DataFrames for metadata, CIF, confidence, full data, and sequence data
+    :return: A dictionary containing DataFrames for multimer metadata, CIF, confidence, full data, and sequence data
     """
     messages: list[dict[str, str | int]] = []
     all_metadata_df = get_multimer_metadata_df()
 
-    metadata_df = check_and_get_metadata_df(
+    multimer_metadata_df = check_and_get_metadata_df(
         entry_id=entry_id,
         all_metadata_df=all_metadata_df,
         csv_file=paths.AF_MULTIMER_METADATA_CSV_PATH,
@@ -758,7 +758,7 @@ def get_multimer_structure_dfs(entry_id: str) -> dict[str, Any]:
         logger.exception(msg)
         raise RuntimeError(msg) from e
     df_dict = {
-        "metadata_df": metadata_df,
+        "structure_metadata_df": multimer_metadata_df,
         "amino_acid_sequences_df": amino_acid_sequences_df,
         "cif_df": cif_df,
         "confidence_df": confidence_df,
@@ -782,8 +782,8 @@ def upload_multimer_prediction(
     """
     Process an AlphaFold multimer prediction and return its parsed data as DataFrames.
 
-    The function assembles metadata for the prediction, optionally persists both
-    metadata and input files to the configured multimer storage directory, and
+    The function assembles multimer metadata for the prediction, optionally persists both
+    multimer metadata and input files to the configured multimer storage directory, and
     parses the provided files into DataFrames:
     - FASTA sequences via fasta_import, key "fasta_df".
     - mmCIF structure via read_alphafold_mmcif.
@@ -797,7 +797,7 @@ def upload_multimer_prediction(
     removed in a finally block.
 
     :param entry_id: Unique identifier for the prediction entry. Used for
-        directory naming and metadata.
+        directory naming and mulitmer metadata.
     :param uniprot_ids: UniProt identifiers associated with the multimer
         prediction.
     :param model_used: Name or identifier of the AlphaFold model used to
@@ -809,11 +809,11 @@ def upload_multimer_prediction(
     :param full_data_file: Path to the full data JSON file. If the JSON
         content is a dict it is normalized into a single-row DataFrame.
         Otherwise, an empty DataFrame is returned and a warning is recorded.
-    :param persist_upload: If True, persist metadata and copy input files into
+    :param persist_upload: If True, persist multimer metadata and copy input files into
         the configured multimer directory. If False, use a temporary directory
-        and do not persist metadata.
+        and do not persist multimer metadata.
     :return: A dictionary containing:
-        - "metadata_df": DataFrame with entry metadata.
+        - "structure_metadata_df": DataFrame with entry multimer metadata.
         - "cif_df": DataFrame parsed from the mmCIF file.
         - "confidence_df": DataFrame loaded from the confidence JSON.
         - "full_data_df": Normalized DataFrame from the full data JSON or empty.
@@ -843,14 +843,14 @@ def upload_multimer_prediction(
     }
 
     try:
-        metadata_df = pd.DataFrame([data])
+        multimer_metadata_df = pd.DataFrame([data])
         if persist_upload:
             exsisting_metadata_df = get_multimer_metadata_df()
             extend_metadata_csv(
                 entry_id=entry_id,
                 metadata_csv=paths.AF_MULTIMER_METADATA_CSV_PATH,
                 existing_metadata_df=exsisting_metadata_df,
-                metadata_df=metadata_df,
+                metadata_df=multimer_metadata_df,
                 messages=messages,
             )
             for file_name in [
@@ -886,7 +886,7 @@ def upload_multimer_prediction(
         cif_df = read_alphafold_mmcif(cif_file)
 
         df_dict = {
-            "metadata_df": metadata_df,
+            "structure_metadata_df": multimer_metadata_df,
             "cif_df": cif_df,
             "confidence_df": confidence_df,
             "full_data_df": full_data_df,

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -430,7 +430,7 @@ class AlphaFoldPredictionLoad(ImportingStep):
     method_description = "Loads the predicted structure of the monomer with the given protein ID out of the AlphaFold DB."
 
     output_keys = [
-        DataKey.METADATA_DF,
+        DataKey.STRUCTURE_METADATA_DF,
         DataKey.CIF_DF,
         DataKey.PAE_DF,
         DataKey.PLDDT_DF,
@@ -494,7 +494,7 @@ class ImportMonomerStructurePredictionFromDisk(ImportingStep):
     method_description = "Load an already uploaded monomer structure prediction from disk into current run"
 
     output_keys = [
-        DataKey.METADATA_DF,
+        DataKey.STRUCTURE_METADATA_DF,
         DataKey.CIF_DF,
         DataKey.PAE_DF,
         DataKey.PLDDT_DF,
@@ -527,7 +527,7 @@ class UploadMultimerPredictions(ImportingStep):
     method_description = "Upload a multimer protein prediction"
 
     output_keys = [
-        DataKey.METADATA_DF,
+        DataKey.STRUCTURE_METADATA_DF,
         DataKey.CIF_DF,
         DataKey.CONFIDENCE_DF,
         DataKey.FULL_DATA_DF,
@@ -593,7 +593,7 @@ class ImportMultimerStructurePredictionFromDisk(ImportingStep):
     method_description = "Load an already uploaded multimer structure prediction from disk into current run"
 
     output_keys = [
-        DataKey.METADATA_DF,
+        DataKey.STRUCTURE_METADATA_DF,
         DataKey.CIF_DF,
         DataKey.CONFIDENCE_DF,
         DataKey.FULL_DATA_DF,

--- a/backend/tests/protzilla/data_analysis/test_crosslinking_validation.py
+++ b/backend/tests/protzilla/data_analysis/test_crosslinking_validation.py
@@ -63,7 +63,7 @@ def test_validate_with_angstrom_deviation(distance, expected):
     crosslinker_information = {"DSS": [5.0, 1.0, 1.0]}  # Länge 5 Å ± 1 Å
     result = validate_with_angstrom_deviation(
         crosslinking_df,
-        metadata_df=pd.DataFrame({"uniprot_accession": ["P12345"]}),
+        structure_metadata_df=pd.DataFrame({"uniprot_accession": ["P12345"]}),
         crosslinker_information=crosslinker_information,
         amino_acid_sequences_df=amino_acid_sequences_df,
         cif_df=cif_df,
@@ -315,7 +315,7 @@ def test_validate_multimer_filters_only_pairs_within_structures_to_validate():
 
     out = validate_with_angstrom_deviation(
         crosslinking_df=crosslinking_df,
-        metadata_df=pd.DataFrame({"uniprot_ids": [["P1", "P2"]]}),
+        structure_metadata_df=pd.DataFrame({"uniprot_ids": [["P1", "P2"]]}),
         crosslinker_information=crosslinker_information,
         cif_df=cif_df,
         amino_acid_sequences_df=sequences_df,
@@ -376,7 +376,7 @@ def test_validate_multimer_no_links_between_structures_returns_empty_and_warning
 
     out = validate_with_angstrom_deviation(
         crosslinking_df=crosslinking_df,
-        metadata_df=pd.DataFrame({"uniprot_ids": [["P1", "P2"]]}),
+        structure_metadata_df=pd.DataFrame({"uniprot_ids": [["P1", "P2"]]}),
         crosslinker_information=crosslinker_information,
         cif_df=cif_df,
         amino_acid_sequences_df=sequences_df,
@@ -436,7 +436,7 @@ def test_validate_multimer_duplicates_rows_for_multiple_peptide_matches_and_vali
 
     out = validate_with_angstrom_deviation(
         crosslinking_df=crosslinking_df,
-        metadata_df=pd.DataFrame({"uniprot_ids": [["P1", "P2"]]}),
+        structure_metadata_df=pd.DataFrame({"uniprot_ids": [["P1", "P2"]]}),
         crosslinker_information=crosslinker_information,
         cif_df=cif_df,
         amino_acid_sequences_df=sequences_df,
@@ -540,7 +540,7 @@ def test_diagrams_of_crosslinking_validation_data_with_drawing_all_vertical_line
 
     figures = diagrams_of_crosslinking_validation_data(
         crosslinking_df=sample_crosslinking_df,
-        metadata_df=pd.DataFrame({"uniprot_accession": ["P12345"]}),
+        structure_metadata_df=pd.DataFrame({"uniprot_accession": ["P12345"]}),
         crosslinker_information=sample_crosslinker_info,
         cif_df=pd.DataFrame(),
         amino_acid_sequences_df=pd.DataFrame(),
@@ -608,7 +608,7 @@ def test_diagrams_of_crosslinking_validation_data_without_drawing_all_vertical_l
 
     figures = diagrams_of_crosslinking_validation_data(
         crosslinking_df=sample_crosslinking_df_with_no_std,
-        metadata_df=pd.DataFrame({"uniprot_accession": ["P12345"]}),
+        structure_metadata_df=pd.DataFrame({"uniprot_accession": ["P12345"]}),
         crosslinker_information=sample_crosslinker_info_matching_sample_crosslinking_df_with_no_std,
         cif_df=pd.DataFrame(),
         amino_acid_sequences_df=pd.DataFrame(),
@@ -670,7 +670,7 @@ def test_diagrams_calls_with_correct_parameters(
 
         figures = diagrams_of_crosslinking_validation_data(
             crosslinking_df=sample_crosslinking_df_with_one_crosslinker,
-            metadata_df=pd.DataFrame({"uniprot_accession": ["P12345"]}),
+            structure_metadata_df=pd.DataFrame({"uniprot_accession": ["P12345"]}),
             crosslinker_information=sample_crosslinker_info_with_one_crosslinker,
             cif_df=pd.DataFrame(),
             amino_acid_sequences_df=pd.DataFrame(),
@@ -781,7 +781,7 @@ def test_validate_multimer_with_invalid_crosslinks():
 
     out = validate_with_angstrom_deviation(
         crosslinking_df=crosslinking_df,
-        metadata_df=pd.DataFrame({"uniprot_ids": ["['P1', 'P2']"]}),
+        structure_metadata_df=pd.DataFrame({"uniprot_ids": ["['P1', 'P2']"]}),
         crosslinker_information=crosslinker_information,
         cif_df=cif_df,
         amino_acid_sequences_df=sequences_df,

--- a/backend/tests/protzilla/importing/test_alphafold_protein_structure_load.py
+++ b/backend/tests/protzilla/importing/test_alphafold_protein_structure_load.py
@@ -148,9 +148,15 @@ def test_fetch_alphafold_monomer_metadata(tmp_path, monkeypatch):
     assert isinstance(out["structure_metadata_df"], pd.DataFrame)
     assert not out["structure_metadata_df"].empty
     assert out["structure_metadata_df"].iloc[0]["uniprot_accession"] == "Q8WP00"
-    assert out["structure_metadata_df"].iloc[0]["model_created_date"] == "2025-08-01T00:00:00Z"
+    assert (
+        out["structure_metadata_df"].iloc[0]["model_created_date"]
+        == "2025-08-01T00:00:00Z"
+    )
     assert out["structure_metadata_df"].iloc[0]["gene"] == "PRM1"
-    assert out["structure_metadata_df"].iloc[0]["model_used"] == "AlphaFold Monomer v2.0 pipeline"
+    assert (
+        out["structure_metadata_df"].iloc[0]["model_used"]
+        == "AlphaFold Monomer v2.0 pipeline"
+    )
 
 
 def test_fetch_alphafold_files_exist(tmp_path, monkeypatch):

--- a/backend/tests/protzilla/importing/test_alphafold_protein_structure_load.py
+++ b/backend/tests/protzilla/importing/test_alphafold_protein_structure_load.py
@@ -127,7 +127,7 @@ def test_fetch_alphafold_returned_keys(tmp_path, monkeypatch):
 
     out = fetch_alphafold_protein_structure("Q8WP00", persist_upload=True)
     assert out.keys() == {
-        "metadata_df",
+        "structure_metadata_df",
         "cif_df",
         "pae_df",
         "plddt_df",
@@ -145,12 +145,12 @@ def test_fetch_alphafold_monomer_metadata(tmp_path, monkeypatch):
     )
     out = fetch_alphafold_protein_structure("Q8WP00", persist_upload=True)
 
-    assert isinstance(out["metadata_df"], pd.DataFrame)
-    assert not out["metadata_df"].empty
-    assert out["metadata_df"].iloc[0]["uniprot_accession"] == "Q8WP00"
-    assert out["metadata_df"].iloc[0]["model_created_date"] == "2025-08-01T00:00:00Z"
-    assert out["metadata_df"].iloc[0]["gene"] == "PRM1"
-    assert out["metadata_df"].iloc[0]["model_used"] == "AlphaFold Monomer v2.0 pipeline"
+    assert isinstance(out["structure_metadata_df"], pd.DataFrame)
+    assert not out["structure_metadata_df"].empty
+    assert out["structure_metadata_df"].iloc[0]["uniprot_accession"] == "Q8WP00"
+    assert out["structure_metadata_df"].iloc[0]["model_created_date"] == "2025-08-01T00:00:00Z"
+    assert out["structure_metadata_df"].iloc[0]["gene"] == "PRM1"
+    assert out["structure_metadata_df"].iloc[0]["model_used"] == "AlphaFold Monomer v2.0 pipeline"
 
 
 def test_fetch_alphafold_files_exist(tmp_path, monkeypatch):
@@ -296,9 +296,9 @@ CA C 2.0
 
     out = get_monomer_structure_dfs("Q8WP00")
 
-    assert isinstance(out["metadata_df"], pd.DataFrame)
-    assert not out["metadata_df"].empty
-    assert out["metadata_df"].iloc[0]["entry_id"] == "Q8WP00"
+    assert isinstance(out["structure_metadata_df"], pd.DataFrame)
+    assert not out["structure_metadata_df"].empty
+    assert out["structure_metadata_df"].iloc[0]["entry_id"] == "Q8WP00"
 
     assert isinstance(out["cif_df"], pd.DataFrame)
     assert not out["cif_df"].empty
@@ -464,9 +464,9 @@ N N
         persist_upload=True,
     )
 
-    assert isinstance(out["metadata_df"], pd.DataFrame)
+    assert isinstance(out["structure_metadata_df"], pd.DataFrame)
     # check metadata contents
-    mdf = out["metadata_df"]
+    mdf = out["structure_metadata_df"]
     assert mdf.iloc[0]["entry_id"] == "M1"
     assert mdf.iloc[0]["uniprot_ids"] == ["X"]
     assert mdf.iloc[0]["model_used"] == "m"
@@ -594,7 +594,7 @@ def test_upload_multimer_prediction_no_persist(tmp_path, monkeypatch):
     )
 
     # verify dataframes are returned
-    assert isinstance(out["metadata_df"], pd.DataFrame)
+    assert isinstance(out["structure_metadata_df"], pd.DataFrame)
     assert isinstance(out["cif_df"], pd.DataFrame)
     # directory should still exist (created for the entry)
     upload_dir = tmp_path / "M2"
@@ -826,7 +826,7 @@ N N
     full_data.write_text(json.dumps({"pae": [[0.1, 0.2], [0.3, 0.4]]}))
 
     out = get_multimer_structure_dfs("M1")
-    assert isinstance(out["metadata_df"], pd.DataFrame)
+    assert isinstance(out["structure_metadata_df"], pd.DataFrame)
     assert isinstance(out["cif_df"], pd.DataFrame)
     assert isinstance(out["amino_acid_sequences_df"], pd.DataFrame)
     assert isinstance(out["confidence_df"], pd.DataFrame)


### PR DESCRIPTION
## Description
fixes #316 
Changed the naming of metadata_df for cl purposes as the dataframes are completely different from normal metadata_dfs.

## Changes
Importing and CL validation uses metadata_df so the changes where made there and for the forms. Also applied changes to the tests.

## Testing
Create a crosslinking (multimer and monomer) workflow and make sure it works with the applied changes.

## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [ ] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
