### PR TITLE
manage output tab selection externally

### DIFF
--- a/frontend/src/components/app/run-screen/run-screen.tsx
+++ b/frontend/src/components/app/run-screen/run-screen.tsx
@@ -98,6 +98,8 @@ export const RunScreen: React.FC = () => {
 
   const [isDownloadModalOpen, openDownloadModal, closeDownloadModal] = useToggleableState(false);
 
+  const [selectedOutputTab, setSelectedOutputTab] = useState<SwitchComponent["name"]>("Tables");
+
   const getFooterMessage = () => {
     const currentTimestamp = new Date();
     const currentHour =
@@ -374,6 +376,10 @@ export const RunScreen: React.FC = () => {
                 styleProps={{ height: "calc(100% - 3em)" }}
                 components={components}
                 hasCardTitle={false}
+                selection={selectedOutputTab}
+                callback={(component) => {
+                  setSelectedOutputTab(component.name);
+                }}
               />
             </StyledCol>
           ) : (


### PR DESCRIPTION
## Description
fixes #345 
Output tabs do not randomly change to previously unselected output types if run data changes

## Changes
The selection of the output component to display is now managed externally in the run screen. Whenever you select e.g. "Tables", all navigation between steps and state reloads will also lead to Tables being displayed (if available), no fallback to plots happens. This also avoids some issues with lazy loading.

Slight caveat: Long loading times of certain output types (e.g. large plots) may still lead to output switching if the previously selected component was that output type but another one gets loaded prior. This should generally be fixed by implementing lazy loading throughout all output types and is out of scope for this fix.


## Testing
Load a sizeable dataset and perform Transformation: Log. Previously, the semi-loaded tables would be shown and then the output would switch to Plots as soon as they are loaded. Now, per default the table is selected and does not switch. If you switch to plots and recalculate, the plots should be shown again. Same with tables, no permanent switching to previously not selected outputs

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
