### PR TITLE
Fix automatic step invalidation with colour / free text fields

### DIFF
--- a/frontend/src/components/core/shared/input-fields/color-input-field/color-input-field.tsx
+++ b/frontend/src/components/core/shared/input-fields/color-input-field/color-input-field.tsx
@@ -45,11 +45,6 @@ export const ColorInputField: React.FC<ColorInputFieldProps> = ({
     setValue(initialValue);
   }, [initialValue]);
 
-  useEffect(() => {
-    onChange(initialValue);
-    //eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   const handleChange = (newValue: string) => {
     setValue(newValue);
     onChange(newValue);

--- a/frontend/src/components/core/shared/input-fields/text-input-field/text-input-field.tsx
+++ b/frontend/src/components/core/shared/input-fields/text-input-field/text-input-field.tsx
@@ -25,11 +25,6 @@ export const TextInputField: React.FC<TextInputFieldProps> = ({
 }) => {
   const [value, setValue] = useState(initialValue);
 
-  useEffect(() => {
-    onChange(initialValue);
-    //eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   const wasThereInputAfterHandleBlurRef = useRef(false);
 
   const handleChange = (value: string) => {


### PR DESCRIPTION
## Description
fixes #318 

## Changes
Removes two bad calls that trigger `onChange` if the input fields get rendered for the first time.

## Testing
Test e.g. with the clustergram by setting some values both in the free text and colour fields. Calculate, navigate away and navigate back to the clustergram. It should stay validated and not turn yellow like previously. Changes in input should still trigger step invalidation as usual

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
