### PR TITLE
Hide PTMsProteinAndPerSample step

### DIFF
--- a/backend/protzilla/all_steps.py
+++ b/backend/protzilla/all_steps.py
@@ -93,6 +93,7 @@ _hidden_steps: list[Step] = [
     importing.ArbitraryCSVImport,
     data_integration.DatabaseIntegrationByUniprot,
     data_integration.PlotGSEAEnrichmentPlot,
+    data_analysis.PTMsProteinAndPerSample,
 ]
 
 


### PR DESCRIPTION
## Description
fixes #365 

Adds PTMsProteinAndPerSample to the list of hidden steps


## Testing
Build the production image using `docker compose up --build -d prod` and open PROTzilla under `localhost:8000`. You shouldn't be able to instantiate the step. Note that this only affects the production builds and **not** our dev setup.

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
