### PR TITLE
Reject tables with too many columns

### DIFF
--- a/frontend/src/components/core/data-table/data-table.tsx
+++ b/frontend/src/components/core/data-table/data-table.tsx
@@ -35,7 +35,7 @@ const FALLBACK_TOO_MANY_COLUMNS = [
     id: "error_too_many_columns2",
   },
 ];
-const MAX_COLUMNS = 10;
+const MAX_COLUMNS = 25;
 
 export const DataTable: React.FC<DataTableProps> = ({
   runName,

--- a/frontend/src/components/core/data-table/data-table.tsx
+++ b/frontend/src/components/core/data-table/data-table.tsx
@@ -25,6 +25,18 @@ export const CustomFooter: React.FC<GridFooterContainerProps> = () => {
   );
 };
 
+const FALLBACK_TOO_MANY_COLUMNS = [
+  {
+    ERROR: "This table contains too many columns to be properly displayed within PROTzilla.",
+    id: "error_too_many_columns1",
+  },
+  {
+    ERROR: "Please download the table using the button below and view using external software.",
+    id: "error_too_many_columns2",
+  },
+];
+const MAX_COLUMNS = 10;
+
 export const DataTable: React.FC<DataTableProps> = ({
   runName,
   tableLabel,
@@ -58,8 +70,13 @@ export const DataTable: React.FC<DataTableProps> = ({
           end_index: endIndex,
         });
 
-        setCurrentRows(response.rows);
-        setTotalRowCount(response.total_row_count);
+        if (response.rows.length > 0 && Object.keys(response.rows[0]).length > MAX_COLUMNS) {
+          setCurrentRows(FALLBACK_TOO_MANY_COLUMNS);
+          setTotalRowCount(FALLBACK_TOO_MANY_COLUMNS.length);
+        } else {
+          setCurrentRows(response.rows);
+          setTotalRowCount(response.total_row_count);
+        }
       } catch (error) {
         console.error("Failed to fetch table data:", error);
       } finally {


### PR DESCRIPTION
## Description
fixes #368 

Tables that have too many columns now won't get shown in the front-end. Instead, an error message is shown. Large tables can still be downloaded using the download as CSV button as usually. This was needed because large tables commonly crashed the front-end

## Changes
- Add a fallback table and necessary condition in the `data-table` component.

## Testing
Use the Support Vector Machine (e.g. in the std workflow after outlier detection) and check out the `X_train` table. It should not load and show an error table instead. Download the CSV and see how it still contains the table we want.

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [x] At least one other developer reviewed and approved the changes
