### PR TITLE
Invalidate plot method if calculation does not return a plot

### DIFF
--- a/backend/protzilla/steps.py
+++ b/backend/protzilla/steps.py
@@ -325,6 +325,9 @@ class Step(ABC):
         else:
             plots = outputs
 
+        if not plots:
+            raise ValueError("Output of plot method is empty.")
+
         self.plots = Plots(plots)
 
     def handle_messages(self, outputs: dict) -> None:


### PR DESCRIPTION
## Description
fixes #377 

Amends the plot output handling to raise an error if no plots were generated. Prior to this, plot steps would be marked as valid even though the calculation failed

## Testing
Use the standard workflow and calculate everything up to this step. For the Bar plot for GO enrichment analysis step make sure that no component is selected and press calculate. You should see the error popping up but also the validation mark turning red.

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
