### PR TITLE
fix selected files resetting after successful multimer upload 

### DIFF
--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -53,14 +53,9 @@ class ImportingStep(Step, ABC):
 
     def modify_form(self, run: Run):
         if run.steps.current_step.calculation_status == "complete":
-            self.form.input_fields[self.index_of_file_input()].value = None
-
-    def index_of_file_input(self):
-        """
-        Returns the index of the FileInput that should be reset by modify_form. This method
-        must be overridden if the FileInput is not index 0.
-        """
-        return 0
+            for field in self.form.input_fields:
+                if isinstance(field, FileInput):
+                    field.value = None
 
 
 class ArbitraryCSVImport(ImportingStep):


### PR DESCRIPTION
## Description
fixes #381
In the multimer uploading step the file input fields now change back to 'no file chosen' after a successful step calculation. (Before the file input fields still showed the file that was previously uploaded, even though it is not actually available anymore) 

## Changes
The modify-form function of the importing step class was adapted to reset all available file input fields after a successful calculation (before this reset was limited to one specified file input field, the first field per default) 


## Testing
Use the multimer uploading step and see that the file input fields change back to 'no file chosen' after a successful step calculation. 

## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [ ] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
