### PR TITLE
Add accepted file endings in forms for cl imports

### DIFF
--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -479,6 +479,7 @@ class CrosslinkingImport(ImportingStep):
                     name="file_path",
                     label="Crosslinking Data file (.xlsx or .csv)",
                     value=None,
+                    accept=".xlsx,.csv",
                 ),
                 TextField(
                     name="organism_ids",
@@ -567,26 +568,31 @@ class UploadMultimerPredictions(ImportingStep):
                     name="amino_acid_sequences",
                     label="Amino acid sequences of proteins in the prediction (required)",
                     value=None,
+                    accept=".fasta,.fa,.faa",
                 ),
                 FileInput(
                     name="cif_file",
                     label="CIF file (required)",
                     value=None,
+                    accept=".cif,.mmcif",
                 ),
                 FileInput(
                     name="confidence_file",
                     label="Confidence summary json file (required)",
                     value=None,
+                    accept=".json",
                 ),
                 FileInput(
                     name="full_data_file",
                     label="Full data json file (required)",
                     value=None,
+                    accept=".json",
                 ),
                 FileInput(
                     name="job_request_file",
                     label="Job request json file (required)",
                     value=None,
+                    accept=".json",
                 ),
                 CheckboxField(
                     name="persist_upload",


### PR DESCRIPTION
## Description
fixes #388 
We now specify accepted file endings in forms for cl imports.

## Changes
All changes are where we define forms for importing.

## Testing
Go through a workflow where we use the multimer structure upload as a step and the crosslinker import and check how the file picker behaves. 

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [x] At least one other developer reviewed and approved the changes
