### PR TITLE
376 default values for cl validation

### DIFF
--- a/backend/main/urls.py
+++ b/backend/main/urls.py
@@ -116,6 +116,21 @@ urlpatterns = [
         name="delete_multimer_structure",
     ),
     path(
+        "api/get_cl_defaults",
+        views_settings.get_cl_defaults,
+        name="get_cl_defaults",
+    ),
+    path(
+        "api/update_cl_default",
+        views_settings.update_cl_default,
+        name="update_cl_default",
+    ),
+    path(
+        "api/delete_cl_default",
+        views_settings.delete_cl_default,
+        name="delete_cl_default",
+    ),
+    path(
         "api/load_ptm_settings",
         views_settings.load_ptm_settings,
         name="load_ptm_settings",

--- a/backend/main/views_settings.py
+++ b/backend/main/views_settings.py
@@ -579,9 +579,12 @@ def delete_multimer_structure(request):
     )
 
 
+# <--- Crosslink defaults --->
+
+
 def get_cl_defaults(request):
     default_operator = DefaultsOperator()
-    defaults = default_operator.get_all_defaults()
+    defaults = default_operator.read_default(name="crosslinker_lengths")
     return JsonResponse(defaults, safe=False)
 
 
@@ -602,13 +605,17 @@ def update_cl_default(request):
         )
 
         cl_default_dict = {
-            "cl_length": cl_length,
-            "cl_upper_deviation": cl_upper_deviation,
-            "cl_lower_deviation": cl_lower_deviation,
+            cl_name: {
+                "cl_length": cl_length,
+                "cl_upper_deviation": cl_upper_deviation,
+                "cl_lower_deviation": cl_lower_deviation,
+            }
         }
         try:
             defaults_operator = DefaultsOperator()
-            defaults_operator.write_default(name=cl_name, value=cl_default_dict)
+            defaults_operator.write_default(
+                name="crosslinker_lengths", value=cl_default_dict
+            )
             return JsonResponse(
                 {
                     "success": True,
@@ -633,7 +640,11 @@ def delete_cl_default(request):
             data = json.loads(request.body)
             cl_name = data.get("cl_name")
             defaults_operator = DefaultsOperator()
-            defaults_operator.delete_default(cl_name)
+            cl_defaults = defaults_operator.read_default(name="crosslinker_lengths")
+            del cl_defaults[cl_name]
+            defaults_operator.write_default(
+                name="crosslinker_lengths", value=cl_defaults
+            )
             return JsonResponse(
                 {
                     "success": True,

--- a/backend/main/views_settings.py
+++ b/backend/main/views_settings.py
@@ -591,10 +591,14 @@ def update_cl_default(request):
         cl_name = data.get("cl_name")
         cl_length = data.get("cl_length") if data.get("cl_length") != "" else 0
         cl_upper_deviation = (
-            data.get("cl_upper_deviation") if data.get("cl_length") != "" else 0
+            data.get("cl_upper_deviation")
+            if data.get("cl_upper_deviation") != ""
+            else 0
         )
         cl_lower_deviation = (
-            data.get("cl_lower_deviation") if data.get("cl_length") != "" else 0
+            data.get("cl_lower_deviation")
+            if data.get("cl_lower_deviation") != ""
+            else 0
         )
 
         cl_default_dict = {
@@ -625,10 +629,26 @@ def update_cl_default(request):
 
 def delete_cl_default(request):
     if request.method == "POST":
-        data = json.loads(request.body)
-        cl_name = data.get("cl_name")
-        defaults_operator = DefaultsOperator()
-        defaults_operator.delete_default(cl_name)
+        try:
+            data = json.loads(request.body)
+            cl_name = data.get("cl_name")
+            defaults_operator = DefaultsOperator()
+            defaults_operator.delete_default(cl_name)
+            return JsonResponse(
+                {
+                    "success": True,
+                    "message": "Default values deleted successfully.",
+                },
+                status=200,
+            )
+        except Exception:
+            return JsonResponse(
+                {"success": False, "message": "Error occured while deleting."},
+                status=405,
+            )
+    return JsonResponse(
+        {"success": False, "message": "Invalid request method"}, status=405
+    )
 
 
 # <--- Databases --->

--- a/backend/main/views_settings.py
+++ b/backend/main/views_settings.py
@@ -604,17 +604,16 @@ def update_cl_default(request):
             else 0
         )
 
-        cl_default_dict = {
-            cl_name: {
+        try:
+            defaults_operator = DefaultsOperator()
+            all_cl_defaults = defaults_operator.read_default(name="crosslinker_lengths")
+            all_cl_defaults[cl_name] = {
                 "cl_length": cl_length,
                 "cl_upper_deviation": cl_upper_deviation,
                 "cl_lower_deviation": cl_lower_deviation,
             }
-        }
-        try:
-            defaults_operator = DefaultsOperator()
             defaults_operator.write_default(
-                name="crosslinker_lengths", value=cl_default_dict
+                name="crosslinker_lengths", value=all_cl_defaults
             )
             return JsonResponse(
                 {

--- a/backend/main/views_settings.py
+++ b/backend/main/views_settings.py
@@ -32,6 +32,7 @@ from backend.protzilla.data_integration.database_query import (
     uniprot_databases,
 )
 from backend.protzilla.disk_operator import YamlOperator
+from backend.protzilla.disk_operator import DefaultsOperator
 from backend.main.views_helper import load_yaml_from_file
 from backend.protzilla.constants.paths import (
     CUSTOM_PLOT_SETTINGS_FILE_STEM,
@@ -576,6 +577,58 @@ def delete_multimer_structure(request):
         csv_file_path=AF_MULTIMER_METADATA_CSV_PATH,
         request=request,
     )
+
+
+def get_cl_defaults(request):
+    default_operator = DefaultsOperator()
+    defaults = default_operator.get_all_defaults()
+    return JsonResponse(defaults, safe=False)
+
+
+def update_cl_default(request):
+    if request.method == "POST":
+        data = json.loads(request.body)
+        cl_name = data.get("cl_name")
+        cl_length = data.get("cl_length") if data.get("cl_length") != "" else 0
+        cl_upper_deviation = (
+            data.get("cl_upper_deviation") if data.get("cl_length") != "" else 0
+        )
+        cl_lower_deviation = (
+            data.get("cl_lower_deviation") if data.get("cl_length") != "" else 0
+        )
+
+        cl_default_dict = {
+            "cl_length": cl_length,
+            "cl_upper_deviation": cl_upper_deviation,
+            "cl_lower_deviation": cl_lower_deviation,
+        }
+        try:
+            defaults_operator = DefaultsOperator()
+            defaults_operator.write_default(name=cl_name, value=cl_default_dict)
+            return JsonResponse(
+                {
+                    "success": True,
+                    "message": (f"Default values updated successfully. "),
+                },
+                status=200,
+            )
+        except Exception:
+            return JsonResponse(
+                {"success": False, "message": "Default values could not be updated."},
+                status=405,
+            )
+    else:
+        return JsonResponse(
+            {"success": False, "message": "Invalid request method"}, status=405
+        )
+
+
+def delete_cl_default(request):
+    if request.method == "POST":
+        data = json.loads(request.body)
+        cl_name = data.get("cl_name")
+        defaults_operator = DefaultsOperator()
+        defaults_operator.delete_default(cl_name)
 
 
 # <--- Databases --->

--- a/backend/protzilla/disk_operator.py
+++ b/backend/protzilla/disk_operator.py
@@ -160,6 +160,50 @@ class Base64Operator:
                 file.write(data)
 
 
+class DefaultsOperator:
+    def __init__(self):
+        self.yaml_operator = YamlOperator()
+
+    def read_default(self, name: str) -> any:
+        with ErrorHandler():
+            if not self.defaults_file.exists():
+                return None
+            defaults = self.yaml_operator.read(self.defaults_file) or {}
+            return defaults.get(name)
+
+    def write_default(self, name: str, value: any) -> None:
+        with ErrorHandler():
+            if not self.defaults_file.parent.exists():
+                self.defaults_file.parent.mkdir(parents=True, exist_ok=True)
+            defaults = {}
+            if self.defaults_file.exists():
+                defaults = self.yaml_operator.read(self.defaults_file) or {}
+            defaults[name] = value
+            self.yaml_operator.write(self.defaults_file, defaults)
+
+    def delete_default(self, name: str) -> None:
+        with ErrorHandler():
+            if not self.defaults_file.exists():
+                return
+            defaults = self.yaml_operator.read(self.defaults_file) or {}
+            if name in defaults:
+                del defaults[name]
+                self.yaml_operator.write(self.defaults_file, defaults)
+
+    def get_all_defaults(self):
+        """Reads all default values from disk. Returns an empty dict if the file doesn't exist."""
+        with ErrorHandler():
+            if not self.defaults_file.exists():
+                return {}
+
+            defaults = self.yaml_operator.read(self.defaults_file)
+            return defaults or {}
+
+    @property
+    def defaults_file(self) -> Path:
+        return paths.USER_DATA_PATH / "defaults.yaml"
+
+
 RUN_FILE = "run.yaml"
 
 
@@ -190,6 +234,7 @@ class DiskOperator:
         self.dataframe_operator = DataFrameOperator()
         self.artifact_operator = ArtifactOperator()
         self.base64_operator = Base64Operator()
+        self.defaults = DefaultsOperator()
 
     def read_run(self, file: Path | None = None) -> StepManager:
         with ErrorHandler():

--- a/backend/protzilla/form.py
+++ b/backend/protzilla/form.py
@@ -242,10 +242,6 @@ class Form:
         if new_field.name in self._value_buffer:
             new_field.value = self._value_buffer.pop(new_field.name)
 
-    def add_field(self, new_field: InputField):
-        self.input_fields.append(new_field)
-        self._field_map[new_field.name] = new_field
-
     def __getitem__(self, fieldname: str) -> InputField:
         "to do form[fieldname] to get the field object"
 

--- a/backend/protzilla/methods/data_analysis.py
+++ b/backend/protzilla/methods/data_analysis.py
@@ -2377,11 +2377,18 @@ class CrosslinkingValidationWithAngstromStep(DataAnalysisStep):
         for crosslinker in crosslinkers:
             field_name = f"{crosslinker}_length"
             if field_name not in form:
-                cl_defaults = run.disk_operator.defaults.read_default(crosslinker)
-                if cl_defaults:
-                    length_default = cl_defaults["cl_length"]
-                    upper_deviation_default = cl_defaults["cl_upper_deviation"]
-                    lower_deviation_default = cl_defaults["cl_lower_deviation"]
+                cl_defaults = (
+                    run.disk_operator.defaults.read_default("crosslinker_lengths") or {}
+                )
+                specific_cl_defaults = cl_defaults.get(crosslinker, {})
+                if specific_cl_defaults:
+                    length_default = specific_cl_defaults.get("cl_length")
+                    upper_deviation_default = specific_cl_defaults.get(
+                        "cl_upper_deviation"
+                    )
+                    lower_deviation_default = specific_cl_defaults.get(
+                        "cl_lower_deviation"
+                    )
                 else:
                     length_default = 0
                     upper_deviation_default = 0

--- a/backend/protzilla/methods/data_analysis.py
+++ b/backend/protzilla/methods/data_analysis.py
@@ -95,13 +95,6 @@ from backend.protzilla.data_analysis.crosslinking_validation import (
     monomer_validation,
     multimer_validation,
 )
-from backend.protzilla.run import Run
-from backend.protzilla.methods.importing import (
-    ImportMonomerStructurePredictionFromDisk,
-    AlphaFoldPredictionLoad,
-    ImportMultimerStructurePredictionFromDisk,
-    UploadMultimerPredictions,
-)
 
 
 class TTestType(Enum):
@@ -2384,20 +2377,32 @@ class CrosslinkingValidationWithAngstromStep(DataAnalysisStep):
         for crosslinker in crosslinkers:
             field_name = f"{crosslinker}_length"
             if field_name not in form:
+                cl_defaults = run.disk_operator.defaults.read_default(crosslinker)
+                if cl_defaults:
+                    length_default = cl_defaults["cl_length"]
+                    upper_deviation_default = cl_defaults["cl_upper_deviation"]
+                    lower_deviation_default = cl_defaults["cl_lower_deviation"]
+                else:
+                    length_default = 0
+                    upper_deviation_default = 0
+                    lower_deviation_default = 0
                 crosslinker_length_field = FloatField(
                     name=field_name,
                     label=f"Length of {crosslinker} in Ångström",
                     min=0,
+                    value=length_default,
                 )
                 upper_bound_length_deviation_field = FloatField(
                     name=f"{crosslinker}_upper_accepted_deviation",
                     label=f"Upper bound on the accepted deviation for {crosslinker} Cross-Links in Ångström (0 equals no bound)",
                     min=0,
+                    value=upper_deviation_default,
                 )
                 lower_bound_length_deviation_field = FloatField(
                     name=f"{crosslinker}_lower_accepted_deviation",
                     label=f"Lower bound on the accepted deviation for {crosslinker} Cross-Links in Ångström (0 equals no bound)",
                     min=0,
+                    value=lower_deviation_default,
                 )
                 form.add_field(crosslinker_length_field)
                 form.add_field(upper_bound_length_deviation_field)
@@ -2435,7 +2440,14 @@ class CrosslinkingValidationWithAngstromDeviation(
     plot_method = staticmethod(monomer_diagrams)
 
     def create_form(self):
-        return Form(label="Ångström Deviation - Monomer", input_fields=[])
+        return Form(
+            label="Ångström Deviation - Monomer",
+            input_fields=[
+                InfoField(
+                    label="Set default cross-link lengths and their upper/lower deviations in settings under 'Cross-Links Defaults'.",
+                )
+            ],
+        )
 
 
 class CrosslinkingValidationWithAngstromDeviationForMultimer(
@@ -2450,5 +2462,9 @@ class CrosslinkingValidationWithAngstromDeviationForMultimer(
     def create_form(self):
         return Form(
             label="Ångström Deviation - Multimer",
-            input_fields=[],
+            input_fields=[
+                InfoField(
+                    label="Set default cross-link lengths and their upper/lower deviations in settings under 'Cross-Links Defaults'.",
+                )
+            ],
         )

--- a/backend/tests/main/test_views_settings.py
+++ b/backend/tests/main/test_views_settings.py
@@ -18,22 +18,31 @@ if not django.apps.apps.ready:
 
 PATCH_PATH = "backend.main.views_settings.DefaultsOperator"
 
+
 def test_get_cl_defaults(monkeypatch):
     request = mock.Mock()
     request.method = "GET"
-    
+
     mock_defaults_operator = mock.Mock()
     mock_defaults_operator.get_all_defaults.return_value = {
-        "DSSO": {"cl_length": 10.3, "cl_upper_deviation": 1.0, "cl_lower_deviation": 1.0}
+        "DSSO": {
+            "cl_length": 10.3,
+            "cl_upper_deviation": 1.0,
+            "cl_lower_deviation": 1.0,
+        }
     }
     monkeypatch.setattr(PATCH_PATH, lambda: mock_defaults_operator)
 
     response = get_cl_defaults(request)
-    
+
     assert response.status_code == 200
     response_data = json.loads(response.content.decode("utf-8"))
     assert response_data == {
-        "DSSO": {"cl_length": 10.3, "cl_upper_deviation": 1.0, "cl_lower_deviation": 1.0}
+        "DSSO": {
+            "cl_length": 10.3,
+            "cl_upper_deviation": 1.0,
+            "cl_lower_deviation": 1.0,
+        }
     }
 
 
@@ -42,9 +51,9 @@ def test_update_cl_default_success(monkeypatch):
         "cl_name": "DSSO",
         "cl_length": 10.3,
         "cl_upper_deviation": 1.0,
-        "cl_lower_deviation": 1.2
+        "cl_lower_deviation": 1.2,
     }
-    
+
     request = mock.Mock()
     request.method = "POST"
     request.body = json.dumps(payload).encode("utf-8")
@@ -60,7 +69,7 @@ def test_update_cl_default_success(monkeypatch):
             "cl_length": 10.3,
             "cl_upper_deviation": 1.0,
             "cl_lower_deviation": 1.2,
-        }
+        },
     )
     assert response.status_code == 200
     response_data = json.loads(response.content.decode("utf-8"))
@@ -69,7 +78,7 @@ def test_update_cl_default_success(monkeypatch):
 
 def test_update_cl_default_exception(monkeypatch):
     payload = {"cl_name": "DSSO", "cl_length": 10.3}
-    
+
     request = mock.Mock()
     request.method = "POST"
     request.body = json.dumps(payload).encode("utf-8")
@@ -87,7 +96,7 @@ def test_update_cl_default_exception(monkeypatch):
 
 def test_delete_cl_default_success(monkeypatch):
     payload = {"cl_name": "DSSO"}
-    
+
     request = mock.Mock()
     request.method = "POST"
     request.body = json.dumps(payload).encode("utf-8")
@@ -98,7 +107,7 @@ def test_delete_cl_default_success(monkeypatch):
     response = delete_cl_default(request)
 
     mock_defaults_operator.delete_default.assert_called_once_with("DSSO")
-    
+
     assert response.status_code == 200
     response_data = json.loads(response.content.decode("utf-8"))
     assert response_data["success"] is True
@@ -106,7 +115,7 @@ def test_delete_cl_default_success(monkeypatch):
 
 def test_delete_cl_default_exception(monkeypatch):
     payload = {"cl_name": "DSSO"}
-    
+
     request = mock.Mock()
     request.method = "POST"
     request.body = json.dumps(payload).encode("utf-8")

--- a/backend/tests/main/test_views_settings.py
+++ b/backend/tests/main/test_views_settings.py
@@ -24,7 +24,7 @@ def test_get_cl_defaults(monkeypatch):
     request.method = "GET"
 
     mock_defaults_operator = mock.Mock()
-    mock_defaults_operator.get_all_defaults.return_value = {
+    mock_defaults_operator.read_default.return_value = {
         "DSSO": {
             "cl_length": 10.3,
             "cl_upper_deviation": 1.0,
@@ -59,16 +59,19 @@ def test_update_cl_default_success(monkeypatch):
     request.body = json.dumps(payload).encode("utf-8")
 
     mock_defaults_operator = mock.Mock()
+    mock_defaults_operator.read_default.return_value = {}
     monkeypatch.setattr(PATCH_PATH, lambda: mock_defaults_operator)
 
     response = update_cl_default(request)
 
     mock_defaults_operator.write_default.assert_called_once_with(
-        name="DSSO",
+        name="crosslinker_lengths",
         value={
-            "cl_length": 10.3,
-            "cl_upper_deviation": 1.0,
-            "cl_lower_deviation": 1.2,
+            "DSSO": {
+                "cl_length": 10.3,
+                "cl_upper_deviation": 1.0,
+                "cl_lower_deviation": 1.2,
+            }
         },
     )
     assert response.status_code == 200
@@ -102,11 +105,17 @@ def test_delete_cl_default_success(monkeypatch):
     request.body = json.dumps(payload).encode("utf-8")
 
     mock_defaults_operator = mock.Mock()
+    mock_defaults_operator.read_default.return_value = {
+        "DSSO": {"cl_length": 10.3}
+    }
     monkeypatch.setattr(PATCH_PATH, lambda: mock_defaults_operator)
 
     response = delete_cl_default(request)
 
-    mock_defaults_operator.delete_default.assert_called_once_with("DSSO")
+    mock_defaults_operator.write_default.assert_called_once_with(
+        name="crosslinker_lengths",
+        value={}
+    )
 
     assert response.status_code == 200
     response_data = json.loads(response.content.decode("utf-8"))

--- a/backend/tests/main/test_views_settings.py
+++ b/backend/tests/main/test_views_settings.py
@@ -105,16 +105,13 @@ def test_delete_cl_default_success(monkeypatch):
     request.body = json.dumps(payload).encode("utf-8")
 
     mock_defaults_operator = mock.Mock()
-    mock_defaults_operator.read_default.return_value = {
-        "DSSO": {"cl_length": 10.3}
-    }
+    mock_defaults_operator.read_default.return_value = {"DSSO": {"cl_length": 10.3}}
     monkeypatch.setattr(PATCH_PATH, lambda: mock_defaults_operator)
 
     response = delete_cl_default(request)
 
     mock_defaults_operator.write_default.assert_called_once_with(
-        name="crosslinker_lengths",
-        value={}
+        name="crosslinker_lengths", value={}
     )
 
     assert response.status_code == 200

--- a/backend/tests/main/test_views_settings.py
+++ b/backend/tests/main/test_views_settings.py
@@ -1,0 +1,122 @@
+import json
+import pytest
+from unittest import mock
+from django.http import JsonResponse
+
+from backend.main.views_settings import (
+    get_cl_defaults,
+    update_cl_default,
+    delete_cl_default,
+)
+
+import os
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.main.settings")
+if not django.apps.apps.ready:
+    django.setup()
+
+PATCH_PATH = "backend.main.views_settings.DefaultsOperator"
+
+def test_get_cl_defaults(monkeypatch):
+    request = mock.Mock()
+    request.method = "GET"
+    
+    mock_defaults_operator = mock.Mock()
+    mock_defaults_operator.get_all_defaults.return_value = {
+        "DSSO": {"cl_length": 10.3, "cl_upper_deviation": 1.0, "cl_lower_deviation": 1.0}
+    }
+    monkeypatch.setattr(PATCH_PATH, lambda: mock_defaults_operator)
+
+    response = get_cl_defaults(request)
+    
+    assert response.status_code == 200
+    response_data = json.loads(response.content.decode("utf-8"))
+    assert response_data == {
+        "DSSO": {"cl_length": 10.3, "cl_upper_deviation": 1.0, "cl_lower_deviation": 1.0}
+    }
+
+
+def test_update_cl_default_success(monkeypatch):
+    payload = {
+        "cl_name": "DSSO",
+        "cl_length": 10.3,
+        "cl_upper_deviation": 1.0,
+        "cl_lower_deviation": 1.2
+    }
+    
+    request = mock.Mock()
+    request.method = "POST"
+    request.body = json.dumps(payload).encode("utf-8")
+
+    mock_defaults_operator = mock.Mock()
+    monkeypatch.setattr(PATCH_PATH, lambda: mock_defaults_operator)
+
+    response = update_cl_default(request)
+
+    mock_defaults_operator.write_default.assert_called_once_with(
+        name="DSSO",
+        value={
+            "cl_length": 10.3,
+            "cl_upper_deviation": 1.0,
+            "cl_lower_deviation": 1.2,
+        }
+    )
+    assert response.status_code == 200
+    response_data = json.loads(response.content.decode("utf-8"))
+    assert response_data["success"] is True
+
+
+def test_update_cl_default_exception(monkeypatch):
+    payload = {"cl_name": "DSSO", "cl_length": 10.3}
+    
+    request = mock.Mock()
+    request.method = "POST"
+    request.body = json.dumps(payload).encode("utf-8")
+
+    mock_defaults_operator = mock.Mock()
+    mock_defaults_operator.write_default.side_effect = Exception("Disk write failed")
+    monkeypatch.setattr(PATCH_PATH, lambda: mock_defaults_operator)
+
+    response = update_cl_default(request)
+
+    assert response.status_code == 405
+    response_data = json.loads(response.content.decode("utf-8"))
+    assert response_data["success"] is False
+
+
+def test_delete_cl_default_success(monkeypatch):
+    payload = {"cl_name": "DSSO"}
+    
+    request = mock.Mock()
+    request.method = "POST"
+    request.body = json.dumps(payload).encode("utf-8")
+
+    mock_defaults_operator = mock.Mock()
+    monkeypatch.setattr(PATCH_PATH, lambda: mock_defaults_operator)
+
+    response = delete_cl_default(request)
+
+    mock_defaults_operator.delete_default.assert_called_once_with("DSSO")
+    
+    assert response.status_code == 200
+    response_data = json.loads(response.content.decode("utf-8"))
+    assert response_data["success"] is True
+
+
+def test_delete_cl_default_exception(monkeypatch):
+    payload = {"cl_name": "DSSO"}
+    
+    request = mock.Mock()
+    request.method = "POST"
+    request.body = json.dumps(payload).encode("utf-8")
+
+    mock_defaults_operator = mock.Mock()
+    mock_defaults_operator.delete_default.side_effect = Exception("Disk delete failed")
+    monkeypatch.setattr(PATCH_PATH, lambda: mock_defaults_operator)
+
+    response = delete_cl_default(request)
+
+    assert response.status_code == 405
+    response_data = json.loads(response.content.decode("utf-8"))
+    assert response_data["success"] is False

--- a/frontend/src/components/app/settings/other-settings/cl-default-settings.tsx
+++ b/frontend/src/components/app/settings/other-settings/cl-default-settings.tsx
@@ -143,14 +143,14 @@ export const CrosslinkDefaultUpload = () => {
     });
     if (response?.success) {
       notify({
-        title: "Cross Link default deleted",
+        title: "Crosslink default deleted",
         message: response.message as string,
         type: "success",
         isClosingAutomatically: true,
       });
     } else {
       notify({
-        title: "Cross Link default deletion failed",
+        title: "Crosslink default deletion failed",
         message: response?.message ?? "Unknown error",
         type: "error",
         isClosingAutomatically: true,
@@ -164,7 +164,7 @@ export const CrosslinkDefaultUpload = () => {
     <div>
       <SectionTitle
         baseComponent={"h2"}
-        title={"Add a default for a specific Cross-Link"}
+        title={"Add a default for a specific crosslink"}
         style={{ paddingBottom: "4px" }}
       />
       <SectionTitle
@@ -183,25 +183,25 @@ export const CrosslinkDefaultUpload = () => {
             {
               type: "text",
               name: "cl_name",
-              label: "Name of the Cross-Link",
+              label: "Name of the crosslink",
               isVisible: true,
             },
             {
               type: "number",
               name: "cl_length",
-              label: "Length of the specified Cross-Link:",
+              label: "Length of the specified crosslink:",
               isVisible: true,
             },
             {
               type: "number",
               name: "cl_upper_deviation",
-              label: "Upper deviation of the specified Cross-Link:",
+              label: "Upper deviation of the specified crosslink:",
               isVisible: true,
             },
             {
               type: "number",
               name: "cl_lower_deviation",
-              label: "Lower deviation of the specified Cross-Link:",
+              label: "Lower deviation of the specified crosslink:",
               isVisible: true,
             },
           ],
@@ -215,9 +215,9 @@ export const CrosslinkDefaultUpload = () => {
           );
         }}
       />
-      <CrosslinkDefaultTitle baseComponent={"h2"} title={"Cross-Link Defaults"} />
+      <CrosslinkDefaultTitle baseComponent={"h2"} title={"Crosslink Defaults"} />
       {crosslinkDefaultList.length === 0 ? (
-        <Text text={"No default values for any cross-links yet."} />
+        <Text text={"No default values for any crosslinks yet."} />
       ) : (
         <CrosslinkDefaultList>
           {crosslinkDefaultList.map((ps) => (

--- a/frontend/src/components/app/settings/other-settings/cl-default-settings.tsx
+++ b/frontend/src/components/app/settings/other-settings/cl-default-settings.tsx
@@ -25,11 +25,14 @@ interface CrosslinkDefaultProps {
   handleDelete?: () => void;
 }
 
-type ApiCrosslinkDefaults = Record<string, {
-  cl_length: number;
-  cl_upper_deviation: number;
-  cl_lower_deviation: number;
-}>;
+type ApiCrosslinkDefaults = Record<
+  string,
+  {
+    cl_length: number;
+    cl_upper_deviation: number;
+    cl_lower_deviation: number;
+  }
+>;
 
 const CrosslinkDefaultContainer = styled.div`
   display: flex;
@@ -65,7 +68,7 @@ const CrosslinkDefaultEntry = ({
             `length: ${String(cl_length)} | ` +
             `accepted upper deviation: ${String(cl_upper_deviation)} | ` +
             `accepted lower deviation: ${String(cl_lower_deviation)}`
-            }
+          }
         />
       </CrosslinkDefaultInfo>
       <SecondaryButton icon={"trash"} isCautious={true} onPress={handleDelete} />
@@ -81,7 +84,7 @@ export const CrosslinkDefaultUpload = () => {
 
   const fetchCrosslinkDefaults = async () => {
     const crosslinkDefaults = (await callApi("get_cl_defaults")) as ApiCrosslinkDefaults | null;
-    
+
     if (crosslinkDefaults) {
       const transformedList: CrosslinkDefaultProps[] = Object.entries(crosslinkDefaults).map(
         ([name, properties]) => ({
@@ -89,7 +92,7 @@ export const CrosslinkDefaultUpload = () => {
           cl_length: properties.cl_length,
           cl_upper_deviation: properties.cl_upper_deviation,
           cl_lower_deviation: properties.cl_lower_deviation,
-        })
+        }),
       );
       setCrosslinkDefaultList(transformedList);
     }
@@ -166,9 +169,7 @@ export const CrosslinkDefaultUpload = () => {
       />
       <SectionTitle
         baseComponent={"h6"}
-        description={
-          "Add new default, update and delete them here."
-        }
+        description={"Add new default, update and delete them here."}
         style={{ paddingBottom: "8px" }}
       />
 
@@ -214,16 +215,9 @@ export const CrosslinkDefaultUpload = () => {
           );
         }}
       />
-      <CrosslinkDefaultTitle
-        baseComponent={"h2"}
-        title={"Cross-Link Defaults"}
-      />
+      <CrosslinkDefaultTitle baseComponent={"h2"} title={"Cross-Link Defaults"} />
       {crosslinkDefaultList.length === 0 ? (
-        <Text
-          text={
-            "No default values for any cross-links yet."
-          }
-        />
+        <Text text={"No default values for any cross-links yet."} />
       ) : (
         <CrosslinkDefaultList>
           {crosslinkDefaultList.map((ps) => (

--- a/frontend/src/components/app/settings/other-settings/cl-default-settings.tsx
+++ b/frontend/src/components/app/settings/other-settings/cl-default-settings.tsx
@@ -1,0 +1,254 @@
+import { useNotification } from "@protzilla/app";
+import { DeleteModal, Form, SecondaryButton, SectionTitle, Text } from "@protzilla/core";
+import { useToggleableState } from "@protzilla/hooks";
+import { spacing } from "@protzilla/theme";
+import { callApi, callApiWithParameters } from "@protzilla/utils";
+import { useEffect, useState } from "react";
+import { styled } from "styled-components";
+
+const CrosslinkDefaultTitle = styled(SectionTitle)`
+  padding-top: ${spacing("large")};
+  padding-bottom: ${spacing("small")};
+`;
+
+const CrosslinkDefaultList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing("verySmall")};
+`;
+
+interface CrosslinkDefaultProps {
+  cl_name: string;
+  cl_length: number;
+  cl_upper_deviation: number;
+  cl_lower_deviation: number;
+  handleDelete?: () => void;
+}
+
+type ApiCrosslinkDefaults = Record<string, {
+  cl_length: number;
+  cl_upper_deviation: number;
+  cl_lower_deviation: number;
+}>;
+
+const CrosslinkDefaultContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding-left: ${spacing("listIndentation")};
+  padding-top: ${spacing("verySmall")};
+  padding-bottom: ${spacing("verySmall")};
+`;
+
+const CrosslinkDefaultInfo = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-content: center;
+  flex-direction: column;
+  width: 90%;
+`;
+
+const CrosslinkDefaultEntry = ({
+  cl_name,
+  cl_length,
+  cl_upper_deviation,
+  cl_lower_deviation,
+  handleDelete,
+}: CrosslinkDefaultProps) => {
+  return (
+    <CrosslinkDefaultContainer>
+      <CrosslinkDefaultInfo>
+        <SectionTitle baseComponent={"h6"} title={cl_name} />
+        <Text
+          text={
+            `length: ${String(cl_length)} | ` +
+            `accepted upper deviation: ${String(cl_upper_deviation)} | ` +
+            `accepted lower deviation: ${String(cl_lower_deviation)}`
+            }
+        />
+      </CrosslinkDefaultInfo>
+      <SecondaryButton icon={"trash"} isCautious={true} onPress={handleDelete} />
+    </CrosslinkDefaultContainer>
+  );
+};
+
+export const CrosslinkDefaultUpload = () => {
+  const notify = useNotification();
+  const [crosslinkDefaultList, setCrosslinkDefaultList] = useState<CrosslinkDefaultProps[]>([]);
+  const [isDeleteModalOpen, openDeleteModal, closeDeleteModal] = useToggleableState(false);
+  const [selectedCrosslinkDefault, setSelectedCrosslinkDefault] = useState<string>("");
+
+  const fetchCrosslinkDefaults = async () => {
+    const crosslinkDefaults = (await callApi("get_cl_defaults")) as ApiCrosslinkDefaults | null;
+    
+    if (crosslinkDefaults) {
+      const transformedList: CrosslinkDefaultProps[] = Object.entries(crosslinkDefaults).map(
+        ([name, properties]) => ({
+          cl_name: name,
+          cl_length: properties.cl_length,
+          cl_upper_deviation: properties.cl_upper_deviation,
+          cl_lower_deviation: properties.cl_lower_deviation,
+        })
+      );
+      setCrosslinkDefaultList(transformedList);
+    }
+  };
+
+  useEffect(() => {
+    void fetchCrosslinkDefaults();
+  }, []);
+
+  const handleAddCrosslinkDefault = async (
+    cl_name: string,
+    cl_length: number,
+    cl_upper_deviation: number,
+    cl_lower_deviation: number,
+  ) => {
+    const response = await callApiWithParameters("update_cl_default", {
+      cl_name: cl_name,
+      cl_length: cl_length,
+      cl_upper_deviation: cl_upper_deviation,
+      cl_lower_deviation: cl_lower_deviation,
+    });
+    if (response?.success) {
+      notify({
+        title: "Crosslink default update",
+        message: response.message as string,
+        type: "success",
+        isClosingAutomatically: true,
+      });
+    } else {
+      notify({
+        title: "Crosslink default update failed",
+        message: response.message ?? "Unknown error",
+        type: "error",
+        isClosingAutomatically: true,
+      });
+    }
+    void fetchCrosslinkDefaults();
+  };
+
+  const onDeleteCrosslinkDefault = (cl_name: string) => {
+    openDeleteModal();
+    setSelectedCrosslinkDefault(cl_name);
+  };
+
+  const handleDeleteCrosslinkDefault = async (cl_name: string) => {
+    const response = await callApiWithParameters("delete_cl_default", {
+      cl_name: cl_name,
+    });
+    if (response?.success) {
+      notify({
+        title: "Cross Link default deleted",
+        message: response.message as string,
+        type: "success",
+        isClosingAutomatically: true,
+      });
+    } else {
+      notify({
+        title: "Cross Link default deletion failed",
+        message: response?.message ?? "Unknown error",
+        type: "error",
+        isClosingAutomatically: true,
+      });
+    }
+    void fetchCrosslinkDefaults();
+    closeDeleteModal();
+  };
+
+  return (
+    <div>
+      <SectionTitle
+        baseComponent={"h2"}
+        title={"Add a default for a specific Cross-Link"}
+        style={{ paddingBottom: "4px" }}
+      />
+      <SectionTitle
+        baseComponent={"h6"}
+        description={
+          "Add new default, update and delete them here."
+        }
+        style={{ paddingBottom: "8px" }}
+      />
+
+      <Form
+        formData={{
+          label: "",
+          labelSubmitButton: "Add defaults",
+          isAutoSubmit: false,
+          hasChangeIndicator: false,
+          input_fields: [
+            {
+              type: "text",
+              name: "cl_name",
+              label: "Name of the Cross-Link",
+              isVisible: true,
+            },
+            {
+              type: "number",
+              name: "cl_length",
+              label: "Length of the specified Cross-Link:",
+              isVisible: true,
+            },
+            {
+              type: "number",
+              name: "cl_upper_deviation",
+              label: "Upper deviation of the specified Cross-Link:",
+              isVisible: true,
+            },
+            {
+              type: "number",
+              name: "cl_lower_deviation",
+              label: "Lower deviation of the specified Cross-Link:",
+              isVisible: true,
+            },
+          ],
+        }}
+        onChange={(data) => {
+          void handleAddCrosslinkDefault(
+            data.cl_name as string,
+            data.cl_length as number,
+            data.cl_upper_deviation as number,
+            data.cl_lower_deviation as number,
+          );
+        }}
+      />
+      <CrosslinkDefaultTitle
+        baseComponent={"h2"}
+        title={"Cross-Link Defaults"}
+      />
+      {crosslinkDefaultList.length === 0 ? (
+        <Text
+          text={
+            "No default values for any cross-links yet."
+          }
+        />
+      ) : (
+        <CrosslinkDefaultList>
+          {crosslinkDefaultList.map((ps) => (
+            <CrosslinkDefaultEntry
+              key={ps.cl_name}
+              cl_name={ps.cl_name}
+              cl_length={ps.cl_length}
+              cl_upper_deviation={ps.cl_upper_deviation}
+              cl_lower_deviation={ps.cl_lower_deviation}
+              handleDelete={() => {
+                onDeleteCrosslinkDefault(ps.cl_name);
+              }}
+            />
+          ))}
+        </CrosslinkDefaultList>
+      )}
+      <DeleteModal
+        isOpen={isDeleteModalOpen}
+        onClose={closeDeleteModal}
+        onConfirm={() => void handleDeleteCrosslinkDefault(selectedCrosslinkDefault)}
+        title={
+          `Defaults for  ` +
+          `"${selectedCrosslinkDefault}" will permanently be deleted. Would you like to proceed?`
+        }
+      />
+    </div>
+  );
+};

--- a/frontend/src/components/app/settings/other-settings/index.ts
+++ b/frontend/src/components/app/settings/other-settings/index.ts
@@ -4,3 +4,4 @@ export * from "./github";
 export * from "./ptm-vis-settings";
 export * from "./monomer-structure-upload";
 export * from "./multimer-structure-upload";
+export * from "./cl-default-settings";

--- a/frontend/src/components/app/settings/settings.tsx
+++ b/frontend/src/components/app/settings/settings.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { styled } from "styled-components";
 
 import {
+  CrosslinkDefaultUpload,
   DatabaseSettings,
   GitHub,
   MonomerStructureUpload,
@@ -135,6 +136,15 @@ export const Settings: React.FC<SettingsProps> = ({
               }}
             />
             <SectionButton
+              id={"crosslink-defaults"}
+              isActive={selectedSetting === "crosslink-defaults"}
+              icon={"prot_structure"}
+              text={"Cross-Links Defaults"}
+              onPress={() => {
+                handleSwitchSection("crosslink-defaults");
+              }}
+            />
+            <SectionButton
               id={"github"}
               isActive={selectedSetting === "github"}
               text={"About Us"}
@@ -152,6 +162,7 @@ export const Settings: React.FC<SettingsProps> = ({
             {selectedSetting === "ptm-vis" && <PTMVisSettings />}
             {selectedSetting === "monomer-structure-upload" && <MonomerStructureUpload />}
             {selectedSetting === "multimer-structure-upload" && <MultimerStructureUpload />}
+            {selectedSetting === "crosslink-defaults" && <CrosslinkDefaultUpload />}
             {selectedSetting === "github" && <GitHub />}
           </SpecificSettings>
           <DiscardModal

--- a/frontend/src/components/app/settings/settings.tsx
+++ b/frontend/src/components/app/settings/settings.tsx
@@ -139,7 +139,7 @@ export const Settings: React.FC<SettingsProps> = ({
               id={"crosslink-defaults"}
               isActive={selectedSetting === "crosslink-defaults"}
               icon={"handleCrosslinkingIcon"}
-              text={"Cross-Links Defaults"}
+              text={"Crosslinks Defaults"}
               onPress={() => {
                 handleSwitchSection("crosslink-defaults");
               }}

--- a/frontend/src/components/app/settings/settings.tsx
+++ b/frontend/src/components/app/settings/settings.tsx
@@ -138,7 +138,7 @@ export const Settings: React.FC<SettingsProps> = ({
             <SectionButton
               id={"crosslink-defaults"}
               isActive={selectedSetting === "crosslink-defaults"}
-              icon={"prot_structure"}
+              icon={"handleCrosslinkingIcon"}
               text={"Cross-Links Defaults"}
               onPress={() => {
                 handleSwitchSection("crosslink-defaults");


### PR DESCRIPTION
## Description
fixes #376 
Before we could only fill in crosslink length, upper and lower deviation after we imported the crosslinking data. Now we can add defaults for them in settings. These values are then automatically used for the crosslink with the same name.

## Changes
I decided to keep the default setting general to be able to work with it for other usages. Therefore one can find the default adding and reading in the same file as the disk_operator. (disk_operator.py) I then use it in views_helpers to create defaults for crosslinks. I also added the tab for the defaults in settings and changed the form for crosslinking validation slightly to take the set defaults as (...well) default.

## Testing
Set a default for DSSO in settings and then create a workflow and check whether the default values you set are then in the corresponding fields in crosslinking validation. Check both multimer and monomer. You can also delete the defaults and see whether the behavior then is as you would expect. You can of course also update the values and see whether everything behaves as expected.


## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
