### PR TITLE
fix crosslinker hover labels in visualization and add legend 

### DIFF
--- a/frontend/src/components/core/shared/molstar-viewer/molstar-viewer.service.ts
+++ b/frontend/src/components/core/shared/molstar-viewer/molstar-viewer.service.ts
@@ -1,5 +1,7 @@
 import { useNotification } from "@protzilla/app";
 import { OrderedSet } from "molstar/lib/mol-data/int";
+import { Loci } from "molstar/lib/mol-model/loci";
+import { StructureElement } from "molstar/lib/mol-model/structure";
 import { PluginUIContext } from "molstar/lib/mol-plugin-ui/context";
 import { MolScriptBuilder as MS } from "molstar/lib/mol-script/language/builder";
 
@@ -15,7 +17,7 @@ type PluginWithCrosslinks = PluginUIContext & {
 };
 
 interface LabelProvider {
-  label: (loci: any) => string | undefined;
+  label: (loci: Loci) => string | undefined;
 }
 
 export async function addCrosslinks(
@@ -68,13 +70,13 @@ export function overrideLabels(plugin: PluginUIContext) {
   const defaultProviders = [...labelManager.providers];
   labelManager.providers = [];
 
-  const getDefaultLabel = (loci: any) =>
+  const getDefaultLabel = (loci: Loci) =>
     defaultProviders
       .map((p) => p.label(loci))
       .filter(Boolean)
       .join(" | ");
 
-  const getAtomIdsFromLoci = (loci: any): string[] => {
+  const getAtomIdsFromLoci = (loci: StructureElement.Loci): string[] => {
     const ids: string[] = [];
 
     for (const element of loci.elements) {
@@ -83,7 +85,7 @@ export function overrideLabels(plugin: PluginUIContext) {
 
       for (let i = 0; i < OrderedSet.size(indices); i++) {
         const idx = OrderedSet.getAt(indices, i);
-        ids.push(String(atoms.value(idx)));
+        ids.push(atoms.value(idx));
       }
     }
 

--- a/frontend/src/components/core/shared/molstar-viewer/molstar-viewer.service.ts
+++ b/frontend/src/components/core/shared/molstar-viewer/molstar-viewer.service.ts
@@ -1,4 +1,5 @@
 import { useNotification } from "@protzilla/app";
+import { OrderedSet } from "molstar/lib/mol-data/int";
 import { PluginUIContext } from "molstar/lib/mol-plugin-ui/context";
 import { MolScriptBuilder as MS } from "molstar/lib/mol-script/language/builder";
 
@@ -8,6 +9,14 @@ import {
   generateCrosslinkCIF,
 } from "./crosslinker-processing";
 import { CROSSLINKER_COLORS } from "./molstar-viewer.config";
+
+type PluginWithCrosslinks = PluginUIContext & {
+  crosslinkerGroups?: Record<CrosslinkerType, string[]>;
+};
+
+interface LabelProvider {
+  label: (loci: any) => string | undefined;
+}
 
 export async function addCrosslinks(
   plugin: PluginUIContext,
@@ -46,6 +55,62 @@ export async function addCrosslinks(
       });
     }
   }
+
+  (plugin as PluginWithCrosslinks).crosslinkerGroups = crosslinkerGroups;
+}
+
+export function overrideLabels(plugin: PluginUIContext) {
+  const labelManager = plugin.managers.lociLabels as {
+    providers: LabelProvider[];
+    addProvider: (p: LabelProvider) => void;
+  };
+
+  const defaultLabelProviders = [...labelManager.providers];
+  labelManager.providers = [];
+
+  plugin.managers.lociLabels.addProvider({
+    label: (loci) => {
+      if (loci.kind !== "element-loci") {
+        return defaultLabelProviders
+          .map((p) => p.label(loci))
+          .filter(Boolean)
+          .join(" | ");
+      }
+
+      const structureElements = loci.elements[0];
+      const firstElement = OrderedSet.getAt(structureElements.indices, 0);
+
+      const crosslinkerGroups = (plugin as PluginWithCrosslinks).crosslinkerGroups;
+      if (!crosslinkerGroups) {
+        return defaultLabelProviders
+          .map((p) => p.label(loci))
+          .filter(Boolean)
+          .join(" | ");
+      }
+
+      const atomId =
+        structureElements.unit.model.atomicHierarchy.atoms.label_atom_id.value(firstElement);
+
+      const crosslinkerGroupWithAtomIds = Object.entries(crosslinkerGroups).find(([, ids]) =>
+        ids.includes(atomId),
+      );
+
+      if (crosslinkerGroupWithAtomIds) {
+        const [crosslinkerGroupName] = crosslinkerGroupWithAtomIds as [CrosslinkerType, string[]];
+        const stringColor = getCrosslinkerColor(crosslinkerGroupName);
+        return `<span style="color:${stringColor}">${crosslinkerGroupName}</span>`;
+      }
+
+      return defaultLabelProviders
+        .map((p) => p.label(loci))
+        .filter(Boolean)
+        .join(" | ");
+    },
+  });
+}
+
+export function getCrosslinkerColor(type: CrosslinkerType) {
+  return `#${CROSSLINKER_COLORS[type].toString(16).padStart(6, "0")}`;
 }
 
 export function handleError(

--- a/frontend/src/components/core/shared/molstar-viewer/molstar-viewer.service.ts
+++ b/frontend/src/components/core/shared/molstar-viewer/molstar-viewer.service.ts
@@ -65,46 +65,77 @@ export function overrideLabels(plugin: PluginUIContext) {
     addProvider: (p: LabelProvider) => void;
   };
 
-  const defaultLabelProviders = [...labelManager.providers];
+  const defaultProviders = [...labelManager.providers];
   labelManager.providers = [];
 
-  plugin.managers.lociLabels.addProvider({
+  const getDefaultLabel = (loci: any) =>
+    defaultProviders
+      .map((p) => p.label(loci))
+      .filter(Boolean)
+      .join(" | ");
+
+  const getAtomIdsFromLoci = (loci: any): string[] => {
+    const ids: string[] = [];
+
+    for (const element of loci.elements) {
+      const { indices, unit } = element;
+      const atoms = unit.model.atomicHierarchy.atoms.label_atom_id;
+
+      for (let i = 0; i < OrderedSet.size(indices); i++) {
+        const idx = OrderedSet.getAt(indices, i);
+        ids.push(String(atoms.value(idx)));
+      }
+    }
+
+    return [...new Set(ids)];
+  };
+
+  const findMatchingAtomPair = (ids: string[]) => {
+    // since the atom-pair of one crosslink is always XL...A, XL...B those are the two ids we need
+    // (there can be atoms of other crosslinks at the exact same place, which is why they are listed here)
+    const getNumber = (id: string) => /\d+/.exec(id)?.[0];
+
+    for (let i = 0; i < ids.length; i++) {
+      for (let j = i + 1; j < ids.length; j++) {
+        if (getNumber(ids[i]) === getNumber(ids[j])) {
+          return [ids[i], ids[j]] as const;
+        }
+      }
+    }
+    return undefined;
+  };
+
+  labelManager.addProvider({
     label: (loci) => {
       if (loci.kind !== "element-loci") {
-        return defaultLabelProviders
-          .map((p) => p.label(loci))
-          .filter(Boolean)
-          .join(" | ");
+        return getDefaultLabel(loci);
       }
-
-      const structureElements = loci.elements[0];
-      const firstElement = OrderedSet.getAt(structureElements.indices, 0);
 
       const crosslinkerGroups = (plugin as PluginWithCrosslinks).crosslinkerGroups;
       if (!crosslinkerGroups) {
-        return defaultLabelProviders
-          .map((p) => p.label(loci))
-          .filter(Boolean)
-          .join(" | ");
+        return getDefaultLabel(loci);
       }
 
-      const atomId =
-        structureElements.unit.model.atomicHierarchy.atoms.label_atom_id.value(firstElement);
+      const atomIds = getAtomIdsFromLoci(loci);
+      const pair = findMatchingAtomPair(atomIds);
 
-      const crosslinkerGroupWithAtomIds = Object.entries(crosslinkerGroups).find(([, ids]) =>
-        ids.includes(atomId),
+      if (!pair) {
+        return getDefaultLabel(loci);
+      }
+
+      const [atomId1, atomId2] = pair;
+
+      const match = Object.entries(crosslinkerGroups).find(
+        ([, ids]) => ids.includes(atomId1) && ids.includes(atomId2),
       );
 
-      if (crosslinkerGroupWithAtomIds) {
-        const [crosslinkerGroupName] = crosslinkerGroupWithAtomIds as [CrosslinkerType, string[]];
-        const stringColor = getCrosslinkerColor(crosslinkerGroupName);
-        return `<span style="color:${stringColor}">${crosslinkerGroupName}</span>`;
+      if (!match) {
+        return getDefaultLabel(loci);
       }
 
-      return defaultLabelProviders
-        .map((p) => p.label(loci))
-        .filter(Boolean)
-        .join(" | ");
+      const [groupName] = match as [CrosslinkerType, string[]];
+      const color = getCrosslinkerColor(groupName);
+      return `<span style="color:${color}">${groupName}</span>`;
     },
   });
 }

--- a/frontend/src/components/core/shared/molstar-viewer/molstar-viewer.tsx
+++ b/frontend/src/components/core/shared/molstar-viewer/molstar-viewer.tsx
@@ -6,7 +6,8 @@ import { renderReact18 } from "molstar/lib/mol-plugin-ui/react18";
 import React, { useEffect, useRef, useState } from "react";
 
 import { MolstarViewerProps } from "./molstar-viewer.props";
-import { addCrosslinks, handleError } from "./molstar-viewer.service";
+import { addCrosslinks, handleError, overrideLabels } from "./molstar-viewer.service";
+import { LegendOverlay } from "./molstar-viewer.ui";
 import { CanvasWrapper, Container } from "./styles";
 import "molstar/lib/mol-plugin-ui/skin/base/base.scss";
 
@@ -48,6 +49,8 @@ const MolstarViewer: React.FC<MolstarViewerProps> = ({ cifText, crosslinks }) =>
           await addCrosslinks(plugin, cifText, crosslinks);
         }
 
+        overrideLabels(plugin);
+
         setIsLoading(false);
       } catch (error: unknown) {
         handleError(error, "MolstarViewer Error:", notify);
@@ -74,6 +77,8 @@ const MolstarViewer: React.FC<MolstarViewerProps> = ({ cifText, crosslinks }) =>
         <SectionTitle baseComponent="h4" description="Structure visualisation is loading..." />
       )}
       <CanvasWrapper ref={containerRef} />
+
+      {crosslinks !== undefined && <LegendOverlay />}
     </Container>
   );
 };

--- a/frontend/src/components/core/shared/molstar-viewer/molstar-viewer.ui.tsx
+++ b/frontend/src/components/core/shared/molstar-viewer/molstar-viewer.ui.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import { CrosslinkerType } from "./crosslinker-processing";
+import { getCrosslinkerColor } from "./molstar-viewer.service";
+import { LegendContainer } from "./styles";
+
+export const LegendOverlay: React.FC = () => {
+  return (
+    <LegendContainer>
+      <div>
+        <span style={{ color: getCrosslinkerColor(CrosslinkerType.ValidIntra) }}>■</span>{" "}
+        {CrosslinkerType.ValidIntra}{" "}
+      </div>
+      <div>
+        <span style={{ color: getCrosslinkerColor(CrosslinkerType.InvalidIntra) }}>■</span>{" "}
+        {CrosslinkerType.InvalidIntra}{" "}
+      </div>
+      <div>
+        <span style={{ color: getCrosslinkerColor(CrosslinkerType.ValidInter) }}>■</span>{" "}
+        {CrosslinkerType.ValidInter}{" "}
+      </div>
+      <div>
+        <span style={{ color: getCrosslinkerColor(CrosslinkerType.InvalidInter) }}>■</span>{" "}
+        {CrosslinkerType.InvalidInter}{" "}
+      </div>
+    </LegendContainer>
+  );
+};

--- a/frontend/src/components/core/shared/molstar-viewer/styles.ts
+++ b/frontend/src/components/core/shared/molstar-viewer/styles.ts
@@ -1,4 +1,4 @@
-import { color } from "@protzilla/theme";
+import { color, font, fontSize, fontWeight } from "@protzilla/theme";
 import { styled } from "styled-components";
 
 export const Container = styled.div`
@@ -10,7 +10,7 @@ export const Container = styled.div`
   gap: 1rem;
 `;
 
-const molstarTheme = {
+export const molstarTheme = {
   primary: color("protzillaDarkBlue"),
   surface: color("protzillaLightGray"),
   hover: color("secondaryHover"),
@@ -247,4 +247,22 @@ export const CanvasWrapper = styled.div`
       background: ${molstarTheme.error} !important;
     }
   }
+`;
+
+export const LegendContainer = styled.div`
+  position: absolute;
+  bottom: 0vh;
+  right: 1.5vh;
+
+  background: ${molstarTheme.surface};
+  color: ${molstarTheme.primary};
+
+  padding: 1vh;
+  font-family: ${font("defaultWithFallbacks")};
+  font-size: ${fontSize("h6")};
+  font-weight: ${fontWeight("default")};
+  border-radius: 0px;
+
+  pointer-events: none;
+  z-index: 10;
 `;

--- a/frontend/src/components/core/shared/molstar-viewer/styles.ts
+++ b/frontend/src/components/core/shared/molstar-viewer/styles.ts
@@ -62,7 +62,7 @@ const lightSurfaces = `
   .msp-plugin .msp-left-panel-controls-buttons,
   .msp-plugin .msp-layout-right,
   .msp-plugin .msp-layout-left,
-  .msp-plugin .msp-highlight-info
+  .msp-plugin .msp-highlight-info,
 `;
 
 const layoutBlocks = `
@@ -76,6 +76,7 @@ const layoutBlocks = `
     .msp-animation-viewport-controls 
     .msp-animation-viewport-controls-select,
   .msp-plugin .msp-viewport-controls-panel,
+  .msp-plugin .msp-no-webgl
 `;
 
 const elementsWithDarkText = `


### PR DESCRIPTION
## Description
fixes #394 
- crosslinker hover labels in visualizations are overwritten by just the info wether they are valid and intra or inter 
- there is a legend for the crosslinker colors in the visualizations that show crosslinker 

## Changes
- molstar-viewer.service.ts ➞ add overwriteLabels function to give crosslinker meaningful labels 
- molstar-viewer.ui.tsx ➞ add an html element displaying a legend in the visualizations 


## Testing
- test visualizations in monomer and multimer workflow 
- check that legend appears (only) when crosslinker are shown in the visualization 
- hover over different types of crosslinks and check wether the correct labels is shown 
- check that all other hover labels remain untouched 

## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [ ] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
