### PR TITLE
fix 'crosslink...' spelling

### DIFF
--- a/backend/protzilla/data_analysis/crosslinking_validation.py
+++ b/backend/protzilla/data_analysis/crosslinking_validation.py
@@ -23,7 +23,7 @@ from backend.protzilla.steps import OutputItem, OutputType
 def get_reactive_atom_of_amino_acid_residue(amino_acid_type: str) -> str:
     """
     Returns the atom of an amino acid residue that is considered reactive for
-    cross-linking. Currently, this always returns the central alpha carbon (CA).
+    crosslinking. Currently, this always returns the central alpha carbon (CA).
 
     :param amino_acid_type: code of the amino acid
 
@@ -42,7 +42,7 @@ def get_coordinates_of_atom_crosslinker_bound_to(
     chain_id: str,
 ) -> tuple[float, float, float]:
     """
-    Returns the Cartesian coordinates of the atom to which the cross-linker is
+    Returns the Cartesian coordinates of the atom to which the crosslinker is
     bound for a given amino acid residue in a protein structure.
 
     :param amino_acid_position_where_crosslinker_bound: 1-based position of the amino acid residue
@@ -174,7 +174,7 @@ def add_protein_crosslink_positions_to_df(
      If either peptide cannot be matched in its corresponding protein sequence, the row
      is removed and a warning message is recorded.
 
-     :param input_crosslinking_df: DataFrame containing cross-linking data with at least the following columns:
+     :param input_crosslinking_df: DataFrame containing crosslinking data with at least the following columns:
                             - 'Peptide1': first peptide sequence
                             - 'Peptide2': second peptide sequence
                             - 'CL_position_within_peptide1': 0-based crosslinker position within Peptide1
@@ -491,12 +491,12 @@ def validate_with_angstrom_deviation(
     structures_to_validate: list,
 ) -> dict:
     """
-    Validates cross-links by comparing the cross-linker lengths with the distances between the linked
-    amino acids in the AlphaFold protein structure. A cross-link is regarded as valid if it matches the AlphaFold data,
-    so if the distance between the connected amino acids in AlphaFold is less than (cross-linker length + the upper allowed deviation)
-    and more than (cross-linker length - the lower allowed deviation). If one of the bounds is zero only the other bound will be applied.
+    Validates crosslinks by comparing the crosslinker lengths with the distances between the linked
+    amino acids in the AlphaFold protein structure. A crosslink is regarded as valid if it matches the AlphaFold data,
+    so if the distance between the connected amino acids in AlphaFold is less than (crosslinker length + the upper allowed deviation)
+    and more than (crosslinker length - the lower allowed deviation). If one of the bounds is zero only the other bound will be applied.
 
-    :param crosslinking_df: DataFrame containing the cross-linking data to validate.
+    :param crosslinking_df: DataFrame containing the crosslinking data to validate.
     :param crosslinker_information: Dictionary mapping crosslinker names to a list of three floats:
                                     [crosslinker_length, upper_accepted_deviation, lower_accepted_deviation].
     :param cif_df: DataFrame containing CIF information (predicted coordinates of all the protein's atoms).
@@ -520,7 +520,7 @@ def validate_with_angstrom_deviation(
 
     # Check if dataframe is empty
     if relevant_crosslinks_df.empty:
-        msg = "There are no cross links between the structures to validate."
+        msg = "There are no crosslinks between the structures to validate."
         messages = [dict(level=logging.WARNING, msg=msg)]
         logger.warning(msg)
         return dict(crosslinking_result_df=pd.DataFrame(), messages=messages)
@@ -540,7 +540,7 @@ def validate_with_angstrom_deviation(
     )
 
     if relevant_crosslinks_df.empty:
-        msg = "There are no cross links between the structures to validate."
+        msg = "There are no crosslinks between the structures to validate."
         messages = [dict(level=logging.WARNING, msg=msg)]
         logger.warning(msg)
         return dict(crosslinking_result_df=pd.DataFrame(), messages=messages)
@@ -654,7 +654,7 @@ def diagrams_of_crosslinking_validation_data(
 ) -> list[Figure]:
     """
     Creates for each crosslinker histogram plots summarizing the distribution of valid and invalid
-    cross-links based on the (AlphaFold-)predicted distances compared to crosslinker lengths and
+    crosslinks based on the (AlphaFold-)predicted distances compared to crosslinker lengths and
     allowed deviations.
 
     For each crosslinker, two histograms are generated:
@@ -664,10 +664,10 @@ def diagrams_of_crosslinking_validation_data(
     Both histograms include vertical reference lines indicating the
     crosslinker length and, if applicable, the upper and/or lower accepted deviation bounds.
 
-    Additionally, a bar plot is created summarizing the total number of cross-links that match
+    Additionally, a bar plot is created summarizing the total number of crosslinks that match
     or do not match the predicted structure across all analyzed crosslinkers.
 
-    :param crosslinking_df: DataFrame containing cross-linking data, including AlphaFold-predicted
+    :param crosslinking_df: DataFrame containing crosslinking data, including AlphaFold-predicted
                             distances, crosslinker identifiers, and validation results.
     :param structure_metadata_df: Dataframe containing metadata.
     :param crosslinker_information: Contains for each Crosslinker:
@@ -678,7 +678,7 @@ def diagrams_of_crosslinking_validation_data(
     :param amino_acid_sequences_df: DataFrame containing the protein sequence
     :return: List of Plotly Figure objects. For each crosslinker, the list contains two histogram
              figures (mean ± 2 standard deviations first, full range second), followed by a final
-             bar plot summarizing valid and invalid cross-links across all crosslinkers.
+             bar plot summarizing valid and invalid crosslinks across all crosslinkers.
     :raises KeyError: If a required crosslinker entry is missing in crosslinker_information.
     """
     if validated_df.empty:
@@ -835,11 +835,11 @@ def diagrams_of_crosslinking_validation_data(
             invalid_crosslinks,
         ],
         names_of_sectors=[
-            f"Cross-Links matching predicted data (intra: {valid_intra_total}, inter: {valid_inter_total})",
-            f"Cross-Links not matching predicted data (intra: {invalid_intra_total}, inter: {invalid_inter_total})",
+            f"Crosslinks matching predicted data (intra: {valid_intra_total}, inter: {valid_inter_total})",
+            f"Crosslinks not matching predicted data (intra: {invalid_intra_total}, inter: {invalid_inter_total})",
         ],
-        heading=f"All Cross-Links used for validation of {structures_to_validate_str}",
-        y_title="Number of Cross-Links",
+        heading=f"All Crosslinks used for validation of {structures_to_validate_str}",
+        y_title="Number of Crosslinks",
     )
     figures.append(bar_plot_over_all_checked_crosslinks)
 

--- a/backend/protzilla/importing/crosslinking_import.py
+++ b/backend/protzilla/importing/crosslinking_import.py
@@ -782,17 +782,17 @@ def crosslinking_import(file_path: Path, organism_ids: str) -> dict:
         else:
             raise ValueError(f"Unsupported file type: {file_path.suffix}")
     except Exception as e:
-        msg = f"An error occurred while reading the file: {e.__class__.__name__} {e}. Please provide a valid cross linking file."
+        msg = f"An error occurred while reading the file: {e.__class__.__name__} {e}. Please provide a valid crosslinking file."
         return error_output(msg, trace=format_trace(traceback.format_exception(e)))
 
     def base_message():
         if file_type == ".csv":
             organism_names_string = ", ".join(scientific_organism_names)
-            return f"{len(good_df)} cross-links for the {organism_names_string} organism(s)"
-        return f"{len(good_df)} cross-links"
+            return f"{len(good_df)} crosslinks for the {organism_names_string} organism(s)"
+        return f"{len(good_df)} crosslinks"
 
     if good_df.empty:
-        msg = f"No cross-links could be processed from this file. File was read successfully, but the data of {base_message()} could be imported."
+        msg = f"No crosslinks could be processed from this file. File was read successfully, but the data of {base_message()} could be imported."
         messages = [dict(level=logging.ERROR, msg=msg)]
     elif failed_df.empty:
         msg = f"Successfully imported data of {base_message()}."

--- a/backend/protzilla/importing/crosslinking_import.py
+++ b/backend/protzilla/importing/crosslinking_import.py
@@ -788,7 +788,9 @@ def crosslinking_import(file_path: Path, organism_ids: str) -> dict:
     def base_message():
         if file_type == ".csv":
             organism_names_string = ", ".join(scientific_organism_names)
-            return f"{len(good_df)} crosslinks for the {organism_names_string} organism(s)"
+            return (
+                f"{len(good_df)} crosslinks for the {organism_names_string} organism(s)"
+            )
         return f"{len(good_df)} crosslinks"
 
     if good_df.empty:

--- a/backend/protzilla/methods/data_analysis.py
+++ b/backend/protzilla/methods/data_analysis.py
@@ -2391,12 +2391,12 @@ class CrosslinkingValidationWithAngstromStep(DataAnalysisStep):
                 )
                 upper_bound_length_deviation_field = FloatField(
                     name=f"{crosslinker}_upper_accepted_deviation",
-                    label=f"Upper bound on the accepted deviation for {crosslinker} Cross-Links in Ångström (0 equals no bound)",
+                    label=f"Upper bound on the accepted deviation for {crosslinker} Crosslinks in Ångström (0 equals no bound)",
                     min=0,
                 )
                 lower_bound_length_deviation_field = FloatField(
                     name=f"{crosslinker}_lower_accepted_deviation",
-                    label=f"Lower bound on the accepted deviation for {crosslinker} Cross-Links in Ångström (0 equals no bound)",
+                    label=f"Lower bound on the accepted deviation for {crosslinker} Crosslinks in Ångström (0 equals no bound)",
                     min=0,
                 )
                 form.add_field(crosslinker_length_field)
@@ -2429,8 +2429,8 @@ class CrosslinkingValidationWithAngstromDeviation(
     CrosslinkingValidationWithAngstromStep
 ):
     display_name = "Ångström Deviation For Monomer Structures"
-    operation = "Cross Linking Validation"
-    method_description = "Validates cross links within the one protein structure based on the difference between the length of the cross linker and the distance between the amino acids which were connected by the cross linker. (in Ångström)"
+    operation = "Crosslinking Validation"
+    method_description = "Validates crosslinks within the one protein structure based on the difference between the length of the crosslinker and the distance between the amino acids which were connected by the crosslinker. (in Ångström)"
     calc_method = staticmethod(monomer_validation)
     plot_method = staticmethod(monomer_diagrams)
 
@@ -2442,8 +2442,8 @@ class CrosslinkingValidationWithAngstromDeviationForMultimer(
     CrosslinkingValidationWithAngstromStep
 ):
     display_name = "Ångström Deviation For Multimer Structures"
-    operation = "Cross Linking Validation"
-    method_description = "Validates cross links between proteins based on the difference between the length of the cross linker and the distance between the amino acids which were connected by the cross linker. (in Ångström)"
+    operation = "Crosslinking Validation"
+    method_description = "Validates crosslinks between proteins based on the difference between the length of the crosslinker and the distance between the amino acids which were connected by the crosslinker. (in Ångström)"
     calc_method = staticmethod(multimer_validation)
     plot_method = staticmethod(multimer_diagrams)
 

--- a/backend/tests/protzilla/data_analysis/test_crosslinking_validation.py
+++ b/backend/tests/protzilla/data_analysis/test_crosslinking_validation.py
@@ -437,7 +437,7 @@ def test_validate_multimer_no_links_between_structures_returns_empty_and_warning
     assert isinstance(messages, list)
     assert len(messages) >= 1
     assert messages[0].get("level") is not None
-    assert "There are no cross links between the structures to validate." in messages[
+    assert "There are no crosslinks between the structures to validate." in messages[
         0
     ].get("msg", "")
 


### PR DESCRIPTION
## Description
fixes #401 
As we agreed the spelling should be: "crosslink...", this was made consistent everywhere. 

## Changes
I changed: 
- "Cross Link..." 
- "Cross-Link..." 
(with and without capital writing) 

## Testing
- Check wether it is spelled correctly everywhere when using the software 
- maybe try to think of other ways it could have been written in the past, that I didn't search for when changing things 

## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [ ] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
