### PR TITLE
fix bug which prevents showing predictions in tables in frontend

### DIFF
--- a/backend/main/views_settings.py
+++ b/backend/main/views_settings.py
@@ -355,6 +355,7 @@ def get_monomer_structure(request):
     ]
 
     df = get_metadata_df(csv_file_path=metadata_csv, expected_columns=expected_columns)
+    df = df.fillna("")
 
     df_infos = df.rename(
         columns={
@@ -470,6 +471,7 @@ def get_multimer_structure(request):
         "model_used",
     ]
     df = get_metadata_df(csv_file_path=metadata_csv, expected_columns=expected_columns)
+    df = df.fillna("")
 
     df_infos = df.rename(
         columns={

--- a/backend/main/views_settings.py
+++ b/backend/main/views_settings.py
@@ -248,6 +248,7 @@ def check_and_copy_files_to_directory(file_names: list, target_dir: str):
         source_file = settings.FILE_UPLOAD_TEMP_DIR / file_name
         success, message = copy_file_to_directory(source_file, target_dir)
         if not success:
+            shutil.rmtree(target_dir, ignore_errors=True)
             return False, message
     return True, "All files successfully uploaded"
 
@@ -325,13 +326,6 @@ def extend_metadata_csv(
     metadata_df: pd.DataFrame,
 ) -> None:
     try:
-        mask = (
-            existing_metadata_df["entry_id"].astype(str).str.upper() == entry_id.upper()
-        )
-        if mask.any():
-            msg = f'Entry ID "{entry_id}" not unique. Entry IDs are compared case insensitively, so "ABC" and "abc" are treated as the same ID.'
-            return False, msg
-
         combined = pd.concat([existing_metadata_df, metadata_df], ignore_index=True)
         combined.to_csv(metadata_csv, index=False)
         return True, f'"{metadata_csv}" updated successfully.'
@@ -382,7 +376,24 @@ def upload_monomer_structure(request):
         pae = data.get("pae")
         fasta_file = data.get("fasta_file")
 
-        # add row to metadata csv
+        if not entry_id:
+            return JsonResponse(
+                data={
+                    "success": False,
+                    "message": "The entry Id cannot be empty or None.",
+                },
+                status=500,
+            )
+
+        if not uniprot_id:
+            return JsonResponse(
+                data={
+                    "success": False,
+                    "message": "Uniprot Id cannot be empty or None.",
+                },
+                status=500,
+            )
+
         ALPHAFOLD_MONOMER_PATH.mkdir(parents=True, exist_ok=True)
         metadata_csv = AF_MONOMER_METADATA_CSV_PATH
 
@@ -404,22 +415,18 @@ def upload_monomer_structure(request):
             "entry_id": entry_id,
             "uniprot_accession": uniprot_id,
             "model_created_date": timestamp,
-            "gene": gene,
-            "model_used": model_used,
+            "gene": "" if gene is None else gene,
+            "model_used": "" if model_used is None else model_used,
         }
 
         metadata_df = pd.DataFrame([new_row])
-        success, message = extend_metadata_csv(
-            entry_id=entry_id,
-            metadata_csv=metadata_csv,
-            existing_metadata_df=existing_metadata_df,
-            metadata_df=metadata_df,
+
+        mask = (
+            existing_metadata_df["entry_id"].astype(str).str.upper() == entry_id.upper()
         )
-        if not success:
-            return JsonResponse(
-                {"success": False, "message": message},
-                status=500,
-            )
+        if mask.any():
+            msg = f'Entry ID "{entry_id}" not unique. Entry IDs are compared case insensitively, so "ABC" and "abc" are treated as the same ID.'
+            return False, msg
 
         #  Copy files to source directory out of temp directory
 
@@ -428,7 +435,22 @@ def upload_monomer_structure(request):
         success, message = check_and_copy_files_to_directory(
             file_names=file_names, target_dir=target_dir
         )
+
         if not success:
+            return JsonResponse(
+                {"success": False, "message": message},
+                status=500,
+            )
+
+        # add row to metadata csv
+        success, message = extend_metadata_csv(
+            entry_id=entry_id,
+            metadata_csv=metadata_csv,
+            existing_metadata_df=existing_metadata_df,
+            metadata_df=metadata_df,
+        )
+        if not success:
+            shutil.rmtree(target_dir, ignore_errors=True)
             return JsonResponse(
                 {"success": False, "message": message},
                 status=500,
@@ -499,7 +521,24 @@ def upload_multimer_structure(request):
 
         ALPHAFOLD_MULTIMER_PATH.mkdir(parents=True, exist_ok=True)
 
-        # add row to metadata csv
+        if not entry_id:
+            return JsonResponse(
+                data={
+                    "success": False,
+                    "message": "The entry Id cannot be empty or None.",
+                },
+                status=500,
+            )
+
+        if not uniprot_ids:
+            return JsonResponse(
+                data={
+                    "success": False,
+                    "message": "Uniprot Ids cannot be empty or None.",
+                },
+                status=500,
+            )
+
         metadata_csv = AF_MULTIMER_METADATA_CSV_PATH
         expected_columns = [
             "entry_id",
@@ -520,21 +559,17 @@ def upload_multimer_structure(request):
             "entry_id": entry_id,
             "uniprot_ids": uniprot_ids_as_list,
             "model_created_date": timestamp,
-            "model_used": model_used,
+            "model_used": "" if model_used is None else model_used,
         }
 
         metadata_df = pd.DataFrame([new_row])
-        success, message = extend_metadata_csv(
-            entry_id=entry_id,
-            metadata_csv=metadata_csv,
-            existing_metadata_df=existing_metadata_df,
-            metadata_df=metadata_df,
+
+        mask = (
+            existing_metadata_df["entry_id"].astype(str).str.upper() == entry_id.upper()
         )
-        if not success:
-            return JsonResponse(
-                {"success": False, "message": message},
-                status=500,
-            )
+        if mask.any():
+            msg = f'Entry ID "{entry_id}" not unique. Entry IDs are compared case insensitively, so "ABC" and "abc" are treated as the same ID.'
+            return False, msg
 
         #  Copy files to source directory out of temp directory
 
@@ -550,6 +585,20 @@ def upload_multimer_structure(request):
             file_names=file_names, target_dir=target_dir
         )
         if not success:
+            return JsonResponse(
+                data={"success": False, "message": message},
+                status=500,
+            )
+
+        # add row to metadata csv
+        success, message = extend_metadata_csv(
+            entry_id=entry_id,
+            metadata_csv=metadata_csv,
+            existing_metadata_df=existing_metadata_df,
+            metadata_df=metadata_df,
+        )
+        if not success:
+            shutil.rmtree(target_dir, ignore_errors=True)
             return JsonResponse(
                 {"success": False, "message": message},
                 status=500,

--- a/backend/protzilla/importing/alphafold_protein_structure_load.py
+++ b/backend/protzilla/importing/alphafold_protein_structure_load.py
@@ -862,6 +862,16 @@ def upload_multimer_prediction(
         will propagate after cleanup of any temporary directory.
     """
 
+    if not entry_id:
+        msg = "The entry Id cannot be empty or None."
+        logger.error(msg)
+        raise ValueError(msg)
+
+    if not uniprot_ids:
+        msg = "Uniprot Ids cannot be empty or None."
+        logger.error(msg)
+        raise ValueError(msg)
+
     messages = []
 
     temp_dir, work_dir = get_correct_af_directories(
@@ -878,7 +888,7 @@ def upload_multimer_prediction(
         "entry_id": entry_id,
         "uniprot_ids": uniprot_ids_as_list,
         "model_created_date": timestamp,
-        "model_used": model_used,
+        "model_used": "" if model_used is None else model_used,
     }
 
     try:

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -548,14 +548,14 @@ class UploadMultimerPredictions(ImportingStep):
             input_fields=[
                 TextField(
                     name="entry_id",
-                    label="Entry ID of the prediction to be loaded into the run.",
+                    label="Entry ID of the prediction to be loaded into the run. (required)",
                 ),
                 InfoField(
                     label="The entry ID should be a unique name given to the uploaded prediction.",
                 ),
                 TextField(
                     name="uniprot_ids",
-                    label="Protein IDs of all proteins used in the sequence. ",
+                    label="Protein IDs of all proteins used in the sequence.",
                 ),
                 InfoField(
                     label="Please provide a list of Protein IDs separated by a comma \n e.g.: P68871, P69905, Q5VSL9."

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -555,7 +555,7 @@ class UploadMultimerPredictions(ImportingStep):
                 ),
                 TextField(
                     name="uniprot_ids",
-                    label="Protein IDs of all proteins used in the sequence.",
+                    label="Protein IDs of all proteins used in the sequence. (required)",
                 ),
                 InfoField(
                     label="Please provide a list of Protein IDs separated by a comma \n e.g.: P68871, P69905, Q5VSL9."

--- a/frontend/src/components/app/settings/other-settings/monomer-structure-upload.tsx
+++ b/frontend/src/components/app/settings/other-settings/monomer-structure-upload.tsx
@@ -200,13 +200,13 @@ export const MonomerStructureUpload = () => {
             {
               type: "text",
               name: "model_used",
-              label: "Alphafold Version Number (required):",
+              label: "Alphafold Version Number:",
               isVisible: true,
             },
             {
               type: "text",
               name: "gene",
-              label: "Gene Name (required):",
+              label: "Gene Name:",
               isVisible: true,
             },
             {

--- a/frontend/src/components/app/settings/other-settings/multimer-structure-upload.tsx
+++ b/frontend/src/components/app/settings/other-settings/multimer-structure-upload.tsx
@@ -202,7 +202,7 @@ export const MultimerStructureUpload = () => {
             {
               type: "text",
               name: "model_used",
-              label: "AlphaFold Model used to predict the structure (required)",
+              label: "AlphaFold Model used to predict the structure",
               isVisible: true,
             },
             {

--- a/frontend/src/components/app/settings/other-settings/multimer-structure-upload.tsx
+++ b/frontend/src/components/app/settings/other-settings/multimer-structure-upload.tsx
@@ -189,7 +189,7 @@ export const MultimerStructureUpload = () => {
             {
               type: "text",
               name: "uniprot_ids",
-              label: "Protein IDs of all proteins used in the sequence (required):",
+              label: "Protein IDs of all proteins used in the sequence:",
               isVisible: true,
             },
             {

--- a/frontend/src/components/app/settings/other-settings/multimer-structure-upload.tsx
+++ b/frontend/src/components/app/settings/other-settings/multimer-structure-upload.tsx
@@ -189,7 +189,7 @@ export const MultimerStructureUpload = () => {
             {
               type: "text",
               name: "uniprot_ids",
-              label: "Protein IDs of all proteins used in the sequence:",
+              label: "Protein IDs of all proteins used in the sequence: (required)",
               isVisible: true,
             },
             {


### PR DESCRIPTION
## Description
fixes #403 
Fixes the bug described in the issue. 

## Changes
The "required" fields are now consistent in forms and settings. Also fixes the bug by turning NaNs into empty strings.

## Testing
Upload a monomer or multimer prediction in forms or settings and leave a non-required field empty. Then look into the settings and the table where uploaded structures are displayed. You should be able to see your uploaded structures in the table there.

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
