### PR TITLE
fix bug that causes user to have to press the download button twice

### DIFF
--- a/frontend/src/components/core/shared/button/button.tsx
+++ b/frontend/src/components/core/shared/button/button.tsx
@@ -560,27 +560,27 @@ export const CSVButton: React.FC<CSVButtonProps> = ({
   ...params
 }) => {
   const [isLoading, setLoading] = useState(false);
-  const [data, setData] = useState([]);
 
   const downloadCSV = async () => {
     setLoading(true);
+    let fetchedRows: any[] = [];
 
     try {
       const response = await callApiWithParameters("get_current_step_table_data/", {
         run_name: runName,
         table_label: tableLabel,
       });
-      setData(response.rows);
+      fetchedRows = response.rows;
     } catch (error) {
       console.error("Failed to fetch table data:", error);
     } finally {
       setLoading(false);
     }
 
-    if (data.length === 0) return;
+    if (fetchedRows.length === 0) return;
 
-    const header = Object.keys(data[0]);
-    const rows = data.map((row) =>
+    const header = Object.keys(fetchedRows[0]);
+    const rows = fetchedRows.map((row) =>
       header
         .map((key) => {
           const value = row[key];


### PR DESCRIPTION
## Description
fixes #353 
Before the user needed to press the download as csv button twice. Now it works as intended and expected, where one only needs to press it once.

## Changes
Before we used `setData` to update the variable `data`. However, the data variable is not updated within the calling of the function but only after it ran through it. This is why when we then checked for `if (data.length === 0)`, data was always empty and therefore we always returned. After the call, data was not empty anymore causing it to work in the second run. Now we store it in a local variable, as there is no need to use a state like this.

## Testing
Go to any workflow and press the 'Download as CSV' button to download a table. It should download it immediately.

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
