### PR TITLE
fix: start frontend only after backend is ready

### DIFF
--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -16,4 +16,4 @@ RUN --mount=type=bind,source=install_scripts/database_download.py,target=install
     python install_scripts/database_download.py
 
 ENV DEBUGMODE=1
-ENTRYPOINT ["bash", "-c", "python -m debugpy --listen 0.0.0.0:5678 backend/manage.py runserver 0.0.0.0:8000 --nothreading"]
+ENTRYPOINT ["bash", "-c", "python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:5678 backend/manage.py runserver 0.0.0.0:8000 --nothreading"]

--- a/backend/main/urls.py
+++ b/backend/main/urls.py
@@ -22,6 +22,7 @@ from . import views, views_settings
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("healthcheck/", views.healthcheck, name="healthcheck"),
     path("api/get_csrf_token/", views.get_csrf_token, name="get_csrf_token"),
     path("api/run_information/", views.run_information_list, name="run_information"),
     path("api/step_list/", views.all_steps, name="step_list"),

--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -10,7 +10,7 @@ import numpy as np
 from plotly.io import to_json
 
 import pandas as pd
-from django.http import JsonResponse, FileResponse
+from django.http import HttpResponse, JsonResponse, FileResponse
 from django.http.request import HttpRequest
 from django.middleware.csrf import get_token
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -55,6 +55,10 @@ hidden_outputs = ["messages"]
 def get_csrf_token(request):
     csrf_token = get_token(request)
     return JsonResponse({"csrfToken": csrf_token, "message": "CSRF cookie set."})
+
+
+def healthcheck(request):
+    return HttpResponse("Healthy", content_type="text/plain")
 
 
 def run_information_list(request):

--- a/compose.yml
+++ b/compose.yml
@@ -25,6 +25,13 @@ services:
       - "5678:5678"
     networks:
       - "dev-network"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-H", "Accept: text/plain", "localhost:8000/healthcheck/"]
+      interval: 30s
+      timeout: 30s
+      retries: 5
+      start_period: 10s
+      start_interval: 1s
 
   vite:
     image: ghcr.io/cschlaffner/protzilla-vite
@@ -41,7 +48,9 @@ services:
     ports:
       - "5173:5173"
     depends_on:
-      - "django"
+      django:
+        condition: service_healthy
+
   
   storybook:
     image: ghcr.io/cschlaffner/protzilla-vite


### PR DESCRIPTION
## Description

fixes the frontend not receiving any data after restarting the dev services (e.g. no workflows/runs). This has the side effect of the frontend not starting if the backend server runs into errors while starting up, which is better than being able to reach an empty frontend imo. Also disables frozen modules to get rid of the debugpy warning

## Changes

- add a simple endpoint at `/healthcheck/` that replies with a plain `HttpResponse` (`urls.py` and `views.py`)
- add a `healthcheck` to the compose service that tries to access this endpoint
  - add the condition that the frontend only starts once the backend is healthy (i.e. reachable)


## Testing

Start ProtZILLA as you usually would, open the home screen in the browser. Then, stop the services but keep the tab open. Start the services again and focus the browser tab; before, this would lead to the frontend eagerly trying to retrieve data from the backend before it was ready. Now, there should be no errors in the logs and the home screen should only show up if there is also data to populate the runs table and workflows row

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
