### PR TITLE
Fix Alphafold json query generation

### DIFF
--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -712,7 +712,7 @@ def get_downloads_from_step(request: HttpRequest):
         {
             "success": True,
             "message": "Got the available download(s) for the step",
-            "data": downloads,
+            "data": {"json_downloads": downloads},
         }
     )
 

--- a/backend/protzilla/importing/query_generation.py
+++ b/backend/protzilla/importing/query_generation.py
@@ -101,5 +101,7 @@ def generate_alphafold_query_json(
     )
     return dict(
         messages=messages,
-        downloads=OutputItem(output_type=OutputType.DOWNLOAD, value={name: [query]}),
+        downloads=OutputItem(
+            output_type=OutputType.DOWNLOAD, value={f"{name}.json": [query]}
+        ),
     )

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -669,7 +669,7 @@ class AlphaFoldQueryJsonGeneration(Step):
                 ),
                 InfoField(
                     label="For each entered ID a number should be entered.\n"
-                    "Numbers should be should be space- or comma-separated."
+                    "Numbers should be space- or comma-separated."
                 ),
                 NumberField(
                     name="model_seed",

--- a/backend/tests/protzilla/importing/test_query_generation.py
+++ b/backend/tests/protzilla/importing/test_query_generation.py
@@ -30,7 +30,7 @@ def test_generate_alphafold_multimer_json_query_for_multiple_proteins(mock_get):
 
     assert len(downloads) == 1
     key = list(downloads.keys())[0]
-    assert key == "name"
+    assert key == "name.json"
 
     parsed_json = downloads[key][0]
 

--- a/frontend/src/components/app/run-screen/run-screen.tsx
+++ b/frontend/src/components/app/run-screen/run-screen.tsx
@@ -182,7 +182,7 @@ export const RunScreen: React.FC = () => {
   const transformDownload = useCallback(
     (output: StepOutputInfo, response: ApiResponse<Download>) => ({
       title: output.label,
-      data: response.data.data,
+      data: response.data.json_downloads,
     }),
     [],
   );

--- a/frontend/src/utils/protzilla-types.ts
+++ b/frontend/src/utils/protzilla-types.ts
@@ -32,7 +32,7 @@ export interface Image {
 }
 
 export interface Download {
-  data: Record<string, unknown>;
+  json_downloads: Record<string, unknown>;
 }
 
 export interface Visualization {


### PR DESCRIPTION
## Description
fixes #409 
How downloads were created in views did not match what the frontend and Download interface expected. Therefore, the frontend crashed while processing the downloads. Changed in views.py how downloads are handed to the frontend.

## Testing
Try to create an alphafold query. The frontend should not crash. Instead, a download button should appear.
<img width="779" height="706" alt="grafik" src="https://github.com/user-attachments/assets/2af3288b-c9a6-4739-96ea-694feb851b63" />



## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [ ] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
