### PR TITLE
313 add server side sorting and filtering of tables

### DIFF
--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -683,62 +683,18 @@ def get_step_plots(request):
         )
 
 
-# # TODO: Move somewhere else
-# def _step_output_as_serialised_table(
-#     label: str, _data: pd.DataFrame | Any, index_delims: tuple[int, int] = (None, None)
-# ) -> list[dict]:
-#     """
-#     Returns the output data of a step as a list of dicts in "records" orientaion, like this:
-#     [{'col1': 1, 'col2': 0.5}, {'col1': 2, 'col2': 0.75}]
-#     Also delimits the return according to index_delims.
-#     If the output could not be serialised, None is returned
-#
-#     :param label: The label of the step output to serialise
-#     :param _data: The data associated with the output
-#     :param index_delims: tuple used as slice begin and end indices to delimit the output
-#     """
-#     start_index = index_delims[0]
-#     end_index = index_delims[1]
-#
-#     # Note: using [None:None] as a slice returns the entire collection
-#     if isinstance(_data, pd.DataFrame):
-#         data = _data.iloc[start_index:end_index].copy()
-#
-#         # Safer than just adding the new column. We assume __id_col is not
-#         # a column name anyone would use
-#         if "id" in data.columns:
-#             data.rename(columns={"id": "__id_col"}, inplace=True)
-#
-#         data["id"] = data.index
-#         cleaned_data = data.replace(np.nan, None)
-#         return cleaned_data.to_dict(orient="records")
-#
-#     # Serialise compatible lists
-#     # TODO #49 this should be refactored to be stored somewhere and not be calculated on every call (can take a few seconds)
-#     # Potential fix: Just do not use lists bro???
-#     elif (
-#         ("_df" not in label) and (label not in hidden_outputs) and (type(_data) == list)
-#     ):
-#         data = pd.DataFrame({label: _data[start_index:end_index]})
-#         data["id"] = data.index
-#         cleaned_data = data.replace(np.nan, None)
-#         return cleaned_data.to_dict(orient="records")
-#
-#     else:
-#         return None
-
 # TODO: Move somewhere else
 def _step_output_as_serialised_table(
     label: str, _data: pd.DataFrame | Any
 ) -> list[dict]:
     """
-        Returns the output data of a step as a list of dicts in "records" orientaion, like this:
-        [{'col1': 1, 'col2': 0.5}, {'col1': 2, 'col2': 0.75}]
-        Also delimits the return according to index_delims.
-        If the output could not be serialised, None is returned
+    Returns the output data of a step as a list of dicts in "records" orientaion, like this:
+    [{'col1': 1, 'col2': 0.5}, {'col1': 2, 'col2': 0.75}]
+    Also delimits the return according to index_delims.
+    If the output could not be serialised, None is returned
 
-        :param label: The label of the step output to serialise
-        :param _data: The data associated with the output
+    :param label: The label of the step output to serialise
+    :param _data: The data associated with the output
     """
     if isinstance(_data, pd.DataFrame):
         data = _data.copy()
@@ -767,6 +723,7 @@ def _step_output_as_serialised_table(
 
     else:
         return None
+
 
 def get_png_from_step(request: HttpRequest):
     """
@@ -816,6 +773,8 @@ def get_current_step_table_data(request):
     end_index = data.get("end_index")
     sort_field = data.get("sort_field")
     sort_direction = data.get("sort_direction", "asc")
+    filters_raw = data.get("filters", "[]")
+    filters = json.loads(filters_raw)
 
     response = {"success": False, "message": None, "rows": None, "total_row_count": 0}
 
@@ -831,8 +790,19 @@ def get_current_step_table_data(request):
         return JsonResponse(response, status=404)
 
     if isinstance(step_output, pd.DataFrame):
+        for f in filters:
+            field = f.get("field")
+            value = f.get("value")
 
-        # SORT ONLY IF USER REQUESTED IT
+            if not field or value is None:
+                continue
+
+            col = step_output[field].astype(str)
+
+            step_output = step_output[
+                col.str.contains(str(value), case=False, na=False)
+            ]
+
         if sort_field:
             step_output = step_output.sort_values(
                 by=sort_field,
@@ -842,7 +812,6 @@ def get_current_step_table_data(request):
 
         response["total_row_count"] = len(step_output)
 
-        # PAGINATION
         paginated_output = step_output.iloc[start_index:end_index]
 
         serialised_output = _step_output_as_serialised_table(
@@ -850,9 +819,9 @@ def get_current_step_table_data(request):
             paginated_output,
         )
     elif (
-            ("_df" not in table_label)
-            and (table_label not in hidden_outputs)
-            and (type(step_output) == list)
+        ("_df" not in table_label)
+        and (table_label not in hidden_outputs)
+        and (type(step_output) == list)
     ):
         if sort_field:
             try:
@@ -865,17 +834,12 @@ def get_current_step_table_data(request):
 
         response["total_row_count"] = len(step_output)
 
-        # PAGINATION
         paginated_output = step_output[start_index:end_index]
 
         serialised_output = _step_output_as_serialised_table(
             table_label,
             paginated_output,
         )
-
-        #
-        # UNSUPPORTED TYPES
-        #
     else:
         serialised_output = None
 
@@ -890,6 +854,7 @@ def get_current_step_table_data(request):
         response["rows"] = serialised_output
 
     return JsonResponse(response)
+
 
 def get_current_step_output_labels(request):
     """

--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -764,16 +764,27 @@ def get_current_step_table_data(request):
     if isinstance(step_output, pd.DataFrame):
         for f in filters:
             field = f.get("field")
+            operator = f.get("operator")
             value = f.get("value")
 
             if not field or value is None:
                 continue
 
-            col = step_output[field].astype(str)
-
-            step_output = step_output[
-                col.str.contains(str(value), case=False, na=False)
-            ]
+            col = step_output[field]
+            if operator == "contains":
+                step_output = step_output[
+                    col.astype(str).str.contains(str(value), case=False, na=False)
+                ]
+            elif operator == "equals":
+                step_output = step_output[
+                    col.astype(str).str.lower() == str(value).lower()
+                ]
+            elif operator == "=":
+                step_output = step_output[col == float(value)]
+            elif operator == ">":
+                step_output = step_output[col > float(value)]
+            elif operator == "<":
+                step_output = step_output[col < float(value)]
 
         if sort_field:
             step_output = step_output.sort_values(

--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -4,9 +4,7 @@ import traceback
 from zipfile import ZipFile
 import re
 import logging
-from typing import Any
 
-import numpy as np
 from plotly.io import to_json
 
 import pandas as pd
@@ -42,6 +40,7 @@ from backend.main.views_helper import (
     get_displayed_steps,
     parameters_from_post,
     sanitize_name,
+    _dataframe_as_datagrid_rows,
 )
 from backend.protzilla.all_steps import get_all_possible_steps
 
@@ -683,48 +682,6 @@ def get_step_plots(request):
         )
 
 
-# TODO: Move somewhere else
-def _step_output_as_serialised_table(
-    label: str, _data: pd.DataFrame | Any
-) -> list[dict]:
-    """
-    Returns the output data of a step as a list of dicts in "records" orientaion, like this:
-    [{'col1': 1, 'col2': 0.5}, {'col1': 2, 'col2': 0.75}]
-    Also delimits the return according to index_delims.
-    If the output could not be serialised, None is returned
-
-    :param label: The label of the step output to serialise
-    :param _data: The data associated with the output
-    """
-    if isinstance(_data, pd.DataFrame):
-        data = _data.copy()
-
-        # Safer than just adding the new column. We assume __id_col is not
-        # a column name anyone would use
-        if "id" in data.columns:
-            data.rename(columns={"id": "__id_col"}, inplace=True)
-
-        data["id"] = data.index
-        cleaned_data = data.replace(np.nan, None)
-        return cleaned_data.to_dict(orient="records")
-
-    # Serialise compatible lists
-    # TODO #49 this should be refactored to be stored somewhere and not be calculated on every call (can take a few seconds)
-    # Potential fix: Just do not use lists bro???
-    elif (
-        ("_df" not in label) and (label not in hidden_outputs) and (type(_data) == list)
-    ):
-        data = pd.DataFrame({label: _data})
-
-        data["id"] = data.index
-        cleaned_data = data.replace(np.nan, None)
-
-        return cleaned_data.to_dict(orient="records")
-
-    else:
-        return None
-
-
 def get_png_from_step(request: HttpRequest):
     """
     API call. Returns a base64-encoded PNG of a step output to the front-end
@@ -757,8 +714,8 @@ def get_png_from_step(request: HttpRequest):
 
 def get_current_step_table_data(request):
     """
-    API call. Returns a specific delimited slice of data from a specified table
-    of the current step's outputs.
+    API call. Returns a specific delimited and optionally filtered and/or sorted slice of data
+    from a specified table of the current step's outputs.
     """
     if request.method != "POST":
         return JsonResponse(
@@ -776,7 +733,12 @@ def get_current_step_table_data(request):
     filters_raw = data.get("filters", "[]")
     filters = json.loads(filters_raw)
 
-    response = {"success": False, "message": None, "rows": None, "total_row_count": 0}
+    response: dict[str, object | None] = {
+        "success": False,
+        "message": None,
+        "rows": None,
+        "total_row_count": 0,
+    }
 
     run = Run(run_name)
 
@@ -788,6 +750,16 @@ def get_current_step_table_data(request):
     if step_output is None:
         response["message"] = "Requested step output not found"
         return JsonResponse(response, status=404)
+
+    # Serialise compatible lists
+    # TODO #49 this should be refactored to be stored somewhere and not be calculated on every call (can take a few seconds)
+    # Potential fix: Do not use lists?
+    if (
+        ("_df" not in table_label)
+        and (table_label not in hidden_outputs)
+        and (type(step_output) == list)
+    ):
+        step_output = pd.DataFrame({table_label: step_output})
 
     if isinstance(step_output, pd.DataFrame):
         for f in filters:
@@ -814,32 +786,7 @@ def get_current_step_table_data(request):
 
         paginated_output = step_output.iloc[start_index:end_index]
 
-        serialised_output = _step_output_as_serialised_table(
-            table_label,
-            paginated_output,
-        )
-    elif (
-        ("_df" not in table_label)
-        and (table_label not in hidden_outputs)
-        and (type(step_output) == list)
-    ):
-        if sort_field:
-            try:
-                step_output = sorted(
-                    step_output,
-                    reverse=(sort_direction == "desc"),
-                )
-            except TypeError:
-                pass
-
-        response["total_row_count"] = len(step_output)
-
-        paginated_output = step_output[start_index:end_index]
-
-        serialised_output = _step_output_as_serialised_table(
-            table_label,
-            paginated_output,
-        )
+        serialised_output = _dataframe_as_datagrid_rows(paginated_output)
     else:
         serialised_output = None
 

--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -683,26 +683,65 @@ def get_step_plots(request):
         )
 
 
+# # TODO: Move somewhere else
+# def _step_output_as_serialised_table(
+#     label: str, _data: pd.DataFrame | Any, index_delims: tuple[int, int] = (None, None)
+# ) -> list[dict]:
+#     """
+#     Returns the output data of a step as a list of dicts in "records" orientaion, like this:
+#     [{'col1': 1, 'col2': 0.5}, {'col1': 2, 'col2': 0.75}]
+#     Also delimits the return according to index_delims.
+#     If the output could not be serialised, None is returned
+#
+#     :param label: The label of the step output to serialise
+#     :param _data: The data associated with the output
+#     :param index_delims: tuple used as slice begin and end indices to delimit the output
+#     """
+#     start_index = index_delims[0]
+#     end_index = index_delims[1]
+#
+#     # Note: using [None:None] as a slice returns the entire collection
+#     if isinstance(_data, pd.DataFrame):
+#         data = _data.iloc[start_index:end_index].copy()
+#
+#         # Safer than just adding the new column. We assume __id_col is not
+#         # a column name anyone would use
+#         if "id" in data.columns:
+#             data.rename(columns={"id": "__id_col"}, inplace=True)
+#
+#         data["id"] = data.index
+#         cleaned_data = data.replace(np.nan, None)
+#         return cleaned_data.to_dict(orient="records")
+#
+#     # Serialise compatible lists
+#     # TODO #49 this should be refactored to be stored somewhere and not be calculated on every call (can take a few seconds)
+#     # Potential fix: Just do not use lists bro???
+#     elif (
+#         ("_df" not in label) and (label not in hidden_outputs) and (type(_data) == list)
+#     ):
+#         data = pd.DataFrame({label: _data[start_index:end_index]})
+#         data["id"] = data.index
+#         cleaned_data = data.replace(np.nan, None)
+#         return cleaned_data.to_dict(orient="records")
+#
+#     else:
+#         return None
+
 # TODO: Move somewhere else
 def _step_output_as_serialised_table(
-    label: str, _data: pd.DataFrame | Any, index_delims: tuple[int, int] = (None, None)
+    label: str, _data: pd.DataFrame | Any
 ) -> list[dict]:
     """
-    Returns the output data of a step as a list of dicts in "records" orientaion, like this:
-    [{'col1': 1, 'col2': 0.5}, {'col1': 2, 'col2': 0.75}]
-    Also delimits the return according to index_delims.
-    If the output could not be serialised, None is returned
+        Returns the output data of a step as a list of dicts in "records" orientaion, like this:
+        [{'col1': 1, 'col2': 0.5}, {'col1': 2, 'col2': 0.75}]
+        Also delimits the return according to index_delims.
+        If the output could not be serialised, None is returned
 
-    :param label: The label of the step output to serialise
-    :param _data: The data associated with the output
-    :param index_delims: tuple used as slice begin and end indices to delimit the output
+        :param label: The label of the step output to serialise
+        :param _data: The data associated with the output
     """
-    start_index = index_delims[0]
-    end_index = index_delims[1]
-
-    # Note: using [None:None] as a slice returns the entire collection
     if isinstance(_data, pd.DataFrame):
-        data = _data.iloc[start_index:end_index].copy()
+        data = _data.copy()
 
         # Safer than just adding the new column. We assume __id_col is not
         # a column name anyone would use
@@ -719,14 +758,15 @@ def _step_output_as_serialised_table(
     elif (
         ("_df" not in label) and (label not in hidden_outputs) and (type(_data) == list)
     ):
-        data = pd.DataFrame({label: _data[start_index:end_index]})
+        data = pd.DataFrame({label: _data})
+
         data["id"] = data.index
         cleaned_data = data.replace(np.nan, None)
+
         return cleaned_data.to_dict(orient="records")
 
     else:
         return None
-
 
 def get_png_from_step(request: HttpRequest):
     """
@@ -774,7 +814,8 @@ def get_current_step_table_data(request):
     table_label = data.get("table_label")
     start_index = data.get("start_index")
     end_index = data.get("end_index")
-    index_delims = (start_index, end_index)
+    sort_field = data.get("sort_field")
+    sort_direction = data.get("sort_direction", "asc")
 
     response = {"success": False, "message": None, "rows": None, "total_row_count": 0}
 
@@ -789,9 +830,54 @@ def get_current_step_table_data(request):
         response["message"] = "Requested step output not found"
         return JsonResponse(response, status=404)
 
-    serialised_output = _step_output_as_serialised_table(
-        table_label, step_output, index_delims
-    )
+    if isinstance(step_output, pd.DataFrame):
+
+        # SORT ONLY IF USER REQUESTED IT
+        if sort_field:
+            step_output = step_output.sort_values(
+                by=sort_field,
+                ascending=(sort_direction == "asc"),
+                na_position="last",
+            )
+
+        response["total_row_count"] = len(step_output)
+
+        # PAGINATION
+        paginated_output = step_output.iloc[start_index:end_index]
+
+        serialised_output = _step_output_as_serialised_table(
+            table_label,
+            paginated_output,
+        )
+    elif (
+            ("_df" not in table_label)
+            and (table_label not in hidden_outputs)
+            and (type(step_output) == list)
+    ):
+        if sort_field:
+            try:
+                step_output = sorted(
+                    step_output,
+                    reverse=(sort_direction == "desc"),
+                )
+            except TypeError:
+                pass
+
+        response["total_row_count"] = len(step_output)
+
+        # PAGINATION
+        paginated_output = step_output[start_index:end_index]
+
+        serialised_output = _step_output_as_serialised_table(
+            table_label,
+            paginated_output,
+        )
+
+        #
+        # UNSUPPORTED TYPES
+        #
+    else:
+        serialised_output = None
 
     if serialised_output is None:
         response["rows"] = [
@@ -803,10 +889,7 @@ def get_current_step_table_data(request):
         response["success"] = True
         response["rows"] = serialised_output
 
-    response["total_row_count"] = len(step_output)
-
     return JsonResponse(response)
-
 
 def get_current_step_output_labels(request):
     """

--- a/backend/main/views_helper.py
+++ b/backend/main/views_helper.py
@@ -1,7 +1,9 @@
 import re
 from pathlib import Path
+from typing import Any
 
 import numpy as np
+import pandas as pd
 
 from backend.protzilla.constants.paths import SETTINGS_PATH
 from backend.protzilla.disk_operator import YamlOperator
@@ -176,3 +178,28 @@ def load_yaml_from_file(path: Path) -> str:
         raise FileNotFoundError(f"File {path} does not exist.")
     with path.open("r") as f:
         return f.read()
+
+
+def _dataframe_as_datagrid_rows(_data: pd.DataFrame) -> list[dict] | None:
+    """
+    Converts dataframes from step outputs into a DataGrid-compatible row format for the frontend.
+    Returns the output data of a step as a list of dicts in "records" orientaion, like this:
+    [{'col1': 1, 'col2': 0.5}, {'col1': 2, 'col2': 0.75}]
+    If the output could not be serialised, None is returned.
+    An id column based on index will be added.
+
+    :param _data: The data associated with the output
+    """
+    if isinstance(_data, pd.DataFrame):
+        data = _data.copy()
+
+        # Safer than just adding the new column. We assume __id_col is not
+        # a column name anyone would use
+        if "id" in data.columns:
+            data.rename(columns={"id": "__id_col"}, inplace=True)
+
+        data["id"] = data.index
+        cleaned_data = data.replace(np.nan, None)
+        return cleaned_data.to_dict(orient="records")
+    else:
+        return None

--- a/frontend/src/components/app/run-screen/run-screen.tsx
+++ b/frontend/src/components/app/run-screen/run-screen.tsx
@@ -1,6 +1,5 @@
 import { Navbar, NodeEditor, PlotDownloadSettings } from "@protzilla/app";
 import {
-  CSVButton,
   DataTable,
   FlexColumn,
   FlexRow,
@@ -65,12 +64,6 @@ const StyledContentContainer = styled.div`
 const StyledContentDiv = styled.div`
   display: flex;
   flex-direction: column;
-`;
-
-const StyledCSVButton = styled(CSVButton)`
-  width: auto;
-  align-self: flex-end;
-  margin-top: ${spacing("buttonGap")};
 `;
 
 const FooterText = styled.div`
@@ -281,7 +274,6 @@ export const RunScreen: React.FC = () => {
   const singleTableComponent = (tableLabel: string) => (
     <StyledContentDiv>
       <DataTable runName={runName} tableLabel={tableLabel} />
-      <StyledCSVButton runName={runName} tableLabel={tableLabel} fileName={tableLabel} />
     </StyledContentDiv>
   );
 

--- a/frontend/src/components/core/data-table/data-table.tsx
+++ b/frontend/src/components/core/data-table/data-table.tsx
@@ -2,6 +2,8 @@ import { Box } from "@mui/material";
 import { ThemeProvider } from "@mui/material/styles";
 import {
   DataGrid,
+  getGridNumericOperators,
+  getGridStringOperators,
   GridColDef,
   GridColumnVisibilityModel,
   GridFilterModel,
@@ -46,6 +48,14 @@ const FALLBACK_TOO_MANY_COLUMNS = [
   },
 ];
 const MAX_COLUMNS = 25;
+
+const stringOperators = getGridStringOperators().filter(
+  (op) => op.value === "contains" || op.value === "equals",
+);
+
+const numericOperators = getGridNumericOperators().filter(
+  (op) => op.value === "=" || op.value === ">" || op.value === "<",
+);
 
 export const DataTable: React.FC<DataTableProps> = ({
   runName,
@@ -111,6 +121,7 @@ export const DataTable: React.FC<DataTableProps> = ({
               align: "left",
               headerAlign: "left",
               filterable: true,
+              filterOperators: isNumeric ? numericOperators : stringOperators,
               valueFormatter: (value: unknown) => value ?? "NaN",
             } as GridColDef;
           });

--- a/frontend/src/components/core/data-table/data-table.tsx
+++ b/frontend/src/components/core/data-table/data-table.tsx
@@ -4,6 +4,7 @@ import {
   DataGrid,
   GridColDef,
   GridColumnVisibilityModel,
+  GridFilterModel,
   GridFooterContainer,
   GridFooterContainerProps,
   GridPagination,
@@ -55,6 +56,17 @@ export const DataTable: React.FC<DataTableProps> = ({
   const [totalRowCount, setTotalRowCount] = useState(0);
   const [isLoading, setLoading] = useState(false);
   const [sortModel, setSortModel] = useState<GridSortModel>([]);
+  const [filterModel, setFilterModel] = useState<GridFilterModel>({
+    items: [],
+  });
+  const [columns, setColumns] = useState<GridColDef[]>([]);
+
+  // necessary for updating which columns exist when switching between tables
+  useEffect(() => {
+    setColumns([]);
+    setFilterModel({ items: [] });
+    setSortModel([]);
+  }, [tableLabel]);
 
   // Fetch data when pagination changes
   useEffect(() => {
@@ -72,7 +84,29 @@ export const DataTable: React.FC<DataTableProps> = ({
           end_index: endIndex,
           sort_field: sortModel[0]?.field,
           sort_direction: sortModel[0]?.sort ?? "asc",
+          filters: JSON.stringify(filterModel.items),
         });
+
+        if (response.rows.length > 0 && columns.length === 0) {
+          const generatedColumns = Object.keys(response.rows[0]).map((key) => {
+            const isNumeric = response.rows.every(
+              (row: TableRecord) => typeof row[key] === "number" || row[key] === null,
+            );
+
+            return {
+              field: key,
+              headerName: key,
+              flex: 1,
+              type: isNumeric ? "number" : "string",
+              align: "left",
+              headerAlign: "left",
+              filterable: true,
+              valueFormatter: (value: unknown) => value ?? "NaN",
+            } as GridColDef;
+          });
+
+          setColumns(generatedColumns);
+        }
 
         if (response.rows.length > 0 && Object.keys(response.rows[0]).length > MAX_COLUMNS) {
           setCurrentRows(FALLBACK_TOO_MANY_COLUMNS);
@@ -89,27 +123,7 @@ export const DataTable: React.FC<DataTableProps> = ({
     };
 
     void fetchData();
-  }, [paginationModel, sortModel, tableLabel, runName]);
-
-  const columns = useMemo(() => {
-    if (currentRows.length === 0) return [];
-
-    return Object.keys(currentRows[0]).map((key) => {
-      const isNumeric = currentRows.every(
-        (row) => typeof row[key] === "number" || row[key] === null,
-      );
-      return {
-        field: key,
-        headerName: key,
-        flex: 1,
-        type: isNumeric ? "number" : "string",
-        align: "left",
-        headerAlign: "left",
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        valueFormatter: (value) => value ?? "NaN",
-      } as GridColDef;
-    });
-  }, [currentRows]);
+  }, [paginationModel, sortModel, filterModel, tableLabel, runName]);
 
   const theme = useMemo(() => getMuiTheme(), []);
   const height = parseInt(baseTheme.sizes.tableRow, 10);
@@ -130,6 +144,9 @@ export const DataTable: React.FC<DataTableProps> = ({
         sortingMode="server"
         sortModel={sortModel}
         onSortModelChange={setSortModel}
+        filterMode="server"
+        filterModel={filterModel}
+        onFilterModelChange={setFilterModel}
         sx={{
           width: "100%",
           height: "100%",
@@ -139,7 +156,6 @@ export const DataTable: React.FC<DataTableProps> = ({
         slots={{
           footer: CustomFooter,
         }}
-        disableColumnFilter
       />
     </ThemeProvider>
   );

--- a/frontend/src/components/core/data-table/data-table.tsx
+++ b/frontend/src/components/core/data-table/data-table.tsx
@@ -11,11 +11,19 @@ import {
   GridPaginationModel,
   GridSortModel,
 } from "@mui/x-data-grid";
-import { baseTheme, getMuiTheme } from "@protzilla/theme";
+import { baseTheme, getMuiTheme, spacing } from "@protzilla/theme";
 import { callApiWithParameters, TableRecord } from "@protzilla/utils";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { styled } from "styled-components";
 
 import { DataTableProps } from "./data-table.props";
+import { CSVButton } from "../shared";
+
+const StyledCSVButton = styled(CSVButton)`
+  width: auto;
+  align-self: flex-end;
+  margin-top: ${spacing("buttonGap")};
+`;
 
 export const CustomFooter: React.FC<GridFooterContainerProps> = () => {
   return (
@@ -60,12 +68,14 @@ export const DataTable: React.FC<DataTableProps> = ({
     items: [],
   });
   const [columns, setColumns] = useState<GridColDef[]>([]);
+  const columnsInitializedRef = useRef(false);
 
   // necessary for updating which columns exist when switching between tables
   useEffect(() => {
     setColumns([]);
     setFilterModel({ items: [] });
     setSortModel([]);
+    columnsInitializedRef.current = false;
   }, [tableLabel]);
 
   // Fetch data when pagination changes
@@ -87,7 +97,7 @@ export const DataTable: React.FC<DataTableProps> = ({
           filters: JSON.stringify(filterModel.items),
         });
 
-        if (response.rows.length > 0 && columns.length === 0) {
+        if (response.rows.length > 0 && !columnsInitializedRef.current) {
           const generatedColumns = Object.keys(response.rows[0]).map((key) => {
             const isNumeric = response.rows.every(
               (row: TableRecord) => typeof row[key] === "number" || row[key] === null,
@@ -106,6 +116,7 @@ export const DataTable: React.FC<DataTableProps> = ({
           });
 
           setColumns(generatedColumns);
+          columnsInitializedRef.current = true;
         }
 
         if (response.rows.length > 0 && Object.keys(response.rows[0]).length > MAX_COLUMNS) {
@@ -156,6 +167,13 @@ export const DataTable: React.FC<DataTableProps> = ({
         slots={{
           footer: CustomFooter,
         }}
+      />
+      <StyledCSVButton
+        runName={runName}
+        tableLabel={tableLabel}
+        fileName={tableLabel}
+        sortModel={sortModel}
+        filterModel={filterModel}
       />
     </ThemeProvider>
   );

--- a/frontend/src/components/core/data-table/data-table.tsx
+++ b/frontend/src/components/core/data-table/data-table.tsx
@@ -8,6 +8,7 @@ import {
   GridFooterContainerProps,
   GridPagination,
   GridPaginationModel,
+  GridSortModel,
 } from "@mui/x-data-grid";
 import { baseTheme, getMuiTheme } from "@protzilla/theme";
 import { callApiWithParameters, TableRecord } from "@protzilla/utils";
@@ -53,6 +54,7 @@ export const DataTable: React.FC<DataTableProps> = ({
   const [currentRows, setCurrentRows] = useState<TableRecord[]>([]);
   const [totalRowCount, setTotalRowCount] = useState(0);
   const [isLoading, setLoading] = useState(false);
+  const [sortModel, setSortModel] = useState<GridSortModel>([]);
 
   // Fetch data when pagination changes
   useEffect(() => {
@@ -68,6 +70,8 @@ export const DataTable: React.FC<DataTableProps> = ({
           table_label: tableLabel,
           start_index: startIndex,
           end_index: endIndex,
+          sort_field: sortModel[0]?.field,
+          sort_direction: sortModel[0]?.sort ?? "asc",
         });
 
         if (response.rows.length > 0 && Object.keys(response.rows[0]).length > MAX_COLUMNS) {
@@ -85,7 +89,7 @@ export const DataTable: React.FC<DataTableProps> = ({
     };
 
     void fetchData();
-  }, [paginationModel, tableLabel, runName]);
+  }, [paginationModel, sortModel, tableLabel, runName]);
 
   const columns = useMemo(() => {
     if (currentRows.length === 0) return [];
@@ -123,6 +127,9 @@ export const DataTable: React.FC<DataTableProps> = ({
         paginationModel={paginationModel}
         onPaginationModelChange={setPaginationModel}
         pageSizeOptions={pageSizeOptions}
+        sortingMode="server"
+        sortModel={sortModel}
+        onSortModelChange={setSortModel}
         sx={{
           width: "100%",
           height: "100%",
@@ -132,7 +139,6 @@ export const DataTable: React.FC<DataTableProps> = ({
         slots={{
           footer: CustomFooter,
         }}
-        disableColumnSorting
         disableColumnFilter
       />
     </ThemeProvider>

--- a/frontend/src/components/core/shared/button/button.props.ts
+++ b/frontend/src/components/core/shared/button/button.props.ts
@@ -1,3 +1,4 @@
+import { GridFilterModel, GridSortModel } from "@mui/x-data-grid";
 import type { Color } from "@protzilla/theme";
 import type { UIStateProps } from "@protzilla/utils";
 import type React from "react";
@@ -74,4 +75,6 @@ export interface CSVButtonProps extends ButtonProps {
   runName: string;
   tableLabel: string;
   fileName?: string;
+  sortModel: GridSortModel;
+  filterModel: GridFilterModel;
 }

--- a/frontend/src/components/core/shared/button/button.props.ts
+++ b/frontend/src/components/core/shared/button/button.props.ts
@@ -78,3 +78,11 @@ export interface CSVButtonProps extends ButtonProps {
   sortModel: GridSortModel;
   filterModel: GridFilterModel;
 }
+
+type TableValue = string | number | boolean | null | undefined | object;
+
+type TableRow = Record<string, TableValue>;
+
+export interface TableDataResponse {
+  rows: TableRow[];
+}

--- a/frontend/src/components/core/shared/button/button.tsx
+++ b/frontend/src/components/core/shared/button/button.tsx
@@ -14,6 +14,7 @@ import {
   ButtonRef,
   CSVButtonProps,
   StatusButtonProps,
+  TableDataResponse,
   ToggleableButtonProps,
 } from "./button.props";
 
@@ -565,16 +566,19 @@ export const CSVButton: React.FC<CSVButtonProps> = ({
 
   const downloadCSV = async () => {
     setLoading(true);
-    let fetchedRows: any[] = [];
+    let fetchedRows: TableDataResponse["rows"] = [];
 
     try {
-      const response = await callApiWithParameters("get_current_step_table_data/", {
-        run_name: runName,
-        table_label: tableLabel,
-        sort_field: sortModel[0]?.field,
-        sort_direction: sortModel[0]?.sort ?? "asc",
-        filters: JSON.stringify(filterModel.items),
-      });
+      const response: TableDataResponse = await callApiWithParameters(
+        "get_current_step_table_data/",
+        {
+          run_name: runName,
+          table_label: tableLabel,
+          sort_field: sortModel[0]?.field,
+          sort_direction: sortModel[0]?.sort ?? "asc",
+          filters: JSON.stringify(filterModel.items),
+        },
+      );
       fetchedRows = response.rows;
     } catch (error) {
       console.error("Failed to fetch table data:", error);

--- a/frontend/src/components/core/shared/button/button.tsx
+++ b/frontend/src/components/core/shared/button/button.tsx
@@ -557,6 +557,8 @@ export const CSVButton: React.FC<CSVButtonProps> = ({
   runName,
   tableLabel,
   fileName = "data.csv",
+  sortModel,
+  filterModel,
   ...params
 }) => {
   const [isLoading, setLoading] = useState(false);
@@ -569,6 +571,9 @@ export const CSVButton: React.FC<CSVButtonProps> = ({
       const response = await callApiWithParameters("get_current_step_table_data/", {
         run_name: runName,
         table_label: tableLabel,
+        sort_field: sortModel[0]?.field,
+        sort_direction: sortModel[0]?.sort ?? "asc",
+        filters: JSON.stringify(filterModel.items),
       });
       fetchedRows = response.rows;
     } catch (error) {
@@ -584,7 +589,6 @@ export const CSVButton: React.FC<CSVButtonProps> = ({
       header
         .map((key) => {
           const value = row[key];
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           if (value == null) return "NaN";
           // Value will be explicitly converted via String()
           const stringified = typeof value === "object" ? JSON.stringify(value) : String(value);


### PR DESCRIPTION
## Description
fixes #313 
Added server-side filtering and sorting.
<img width="864" height="226" alt="grafik" src="https://github.com/user-attachments/assets/da0caa22-a20e-4f5b-a463-548ba8558f77" />
You can filter only one column at a time because filtering on two columns is available only in the MUI X Data Grid Pro Edition, not in the community edition.

## Changes

- added sorting and filtering parameters to get_current_step_table_data in views.py
- renamed _step_output_as_serialised_table to _dataframe_as_datagrid_rows and moved it from views.py to views_helper.py
- frontend changes for the new parameters, mainly in data-table.tsx


## Testing

- do an import (e.g. MaxQuantImport)
- check that you can sort based on the different columns
- check different filters (maybe for strings and for numbers)
- check filtering and sorting for tables that are based on lists (like contaminants in the MaxQuantImport) as well
- filter and sort a list, download it and check that the download matches the filtered down and sorted version displayed

## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [ ] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
