### PR TITLE
fix: sort input/output keys

### DIFF
--- a/frontend/src/components/app/run-screen/node-editor/StepNode.tsx
+++ b/frontend/src/components/app/run-screen/node-editor/StepNode.tsx
@@ -153,7 +153,7 @@ export default function StepNode({ data }: NodeProps<StepNodeType>) {
       </TextContainer>
 
       {/* Input handles */}
-      {data.step.input_keys.map((input, index) => {
+      {data.step.input_keys.sort().map((input, index) => {
         const InputIcon = DATA_TYPE_ICON_MAP[input];
         return (
           <Handle
@@ -206,7 +206,7 @@ export default function StepNode({ data }: NodeProps<StepNodeType>) {
       })}
 
       {/* Output handles */}
-      {data.step.output_keys.map((output, index) => {
+      {data.step.output_keys.sort().map((output, index) => {
         const OutputIcon = DATA_TYPE_ICON_MAP[output];
         return (
           <Handle


### PR DESCRIPTION
## Description
fixes #426 
Ordered the handles

## Changes
`StepNode.tsx`, added a simple `.sort()`


## Testing
See if the handles are sorted, even after repeated server restarts. Also we shouldn't have any more spaghetti now especially with the CL validation steps

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [x] At least one other developer reviewed and approved the changes
