### PR TITLE
311 fix run deletion

### DIFF
--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -197,21 +197,25 @@ def delete_run(request):
         run_name = data.get("run_name")
 
         try:
-            if run_name not in Run._instances:
-                delete_run_folder(run_name)
+            if run_name in Run._instances:
+                try:
+                    run = Run(run_name)
+                    run.delete_run()
+                except Exception:
+                    Run._instances.pop(run_name, None)
+                    delete_run_folder(run_name)
             else:
-                run = Run(run_name)
-                run.delete_run()
+                delete_run_folder(run_name)
 
             return JsonResponse({"success": True, "message": "Deleted run"})
         except Exception as e:
-            traceback.print_exc()  # not sure if it still needs to be here
             return JsonResponse(
                 {
                     "success": False,
-                    "message": format_trace(traceback.format_exception(e)),
+                    "message": str(e),
+                    "traceback": format_trace(traceback.format_exception(e)),
                 },
-                status=404,
+                status=500,
             )
     else:
         return JsonResponse(

--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -198,6 +198,14 @@ def delete_run(request):
 
         try:
             if run_name in Run._instances:
+                # there are the following three cases:
+                # 1. The run is in memory and healthy: We successfully retrieve it and
+                #    use its delete method to clean up state and release file locks.
+                # 2. The run is in memory but corrupted: Instantiation fails,
+                #    so we catch the exception, forcefully evict it from the cache,
+                #    and wipe the folder directly.
+                # 3. (Handled by the else block) The run is NOT in memory: We bypass
+                #    instantiation entirely to save resources and directly wipe the folder.
                 try:
                     run = Run(run_name)
                     run.delete_run()

--- a/frontend/src/components/app/runs-table/runs-table.tsx
+++ b/frontend/src/components/app/runs-table/runs-table.tsx
@@ -1,4 +1,4 @@
-import { RunEditMenu } from "@protzilla/app";
+import { RunEditMenu, useNotification } from "@protzilla/app";
 import {
   DeleteModal,
   Icon,
@@ -113,6 +113,7 @@ export const RunsTable: React.FC<RunsTableProps> = ({
 }) => {
   const navigate = useNavigate();
   const theme = useTheme();
+  const notify = useNotification();
 
   const { handlePointerEnter, handlePointerLeave, showTooltip, mouseAnchor } =
     useTooltipScheduling(true);
@@ -171,11 +172,19 @@ export const RunsTable: React.FC<RunsTableProps> = ({
         setIsDeleteModalOpen(false);
         setRuns(updated);
       } else {
-        alert(`Failed to delete run: ${String(response?.message ?? "Unknown error")}`);
+        notify({
+          title: "Error",
+          message: `Failed to delete run: ${String(response?.message ?? "Unknown error")}`,
+          type: "error",
+        });
       }
     } catch (error) {
       console.error("Error deleting run:", error);
-      alert("An unexpected error occurred while deleting the run.");
+      notify({
+        title: "Error",
+        message: "An unexpected error occurred while deleting the run.",
+        type: "error",
+      });
     }
   };
 

--- a/frontend/src/components/app/runs-table/runs-table.tsx
+++ b/frontend/src/components/app/runs-table/runs-table.tsx
@@ -162,11 +162,21 @@ export const RunsTable: React.FC<RunsTableProps> = ({
     setRuns(updated);
   };
 
-  const handleDeleteRun = (runName: string) => {
-    void callApiWithParameters("delete_run/", { run_name: runName });
-    const updated = runs.filter((run) => run.run_name !== runName);
-    setIsDeleteModalOpen(false);
-    setRuns(updated);
+  const handleDeleteRun = async (runName: string) => {
+    try {
+      const response = await callApiWithParameters("delete_run/", { run_name: runName });
+
+      if (response?.success) {
+        const updated = runs.filter((run) => run.run_name !== runName);
+        setIsDeleteModalOpen(false);
+        setRuns(updated);
+      } else {
+        alert(`Failed to delete run: ${String(response?.message ?? "Unknown error")}`);
+      }
+    } catch (error) {
+      console.error("Error deleting run:", error);
+      alert("An unexpected error occurred while deleting the run.");
+    }
   };
 
   const handleContinueRun = (runName: string) => {
@@ -331,7 +341,7 @@ export const RunsTable: React.FC<RunsTableProps> = ({
         title={`Delete run "${actionRunName}"?`}
         isOpen={isDeleteModalOpen}
         onConfirm={() => {
-          handleDeleteRun(actionRunName);
+          void handleDeleteRun(actionRunName);
         }}
         onClose={() => {
           setIsDeleteModalOpen(false);


### PR DESCRIPTION
## Description
fixes #311 
The bug is well-documented in the original issue, so I will focus on the fixes below.

## Changes
As @tE3m already correctly identified, deletion was failing silently because the server tried to instantiate the run first, which breaks if the run is corrupted. 
Now, if instantiation fails, we catch the error and force-delete the run directly, bypassing the need to instantiate the run in order to call delete_run. 
I also changed the error message sent to the frontend slightly to better reflect what is actually going wrong. 
Lastly, I also changed how the frontend handles deletions. Instead of expecting the deletion to work and already update the run table accordingly, we wait for the run to be successfully deleted. Only after that we actually update the table. 
If the deletion fails, we now display an error for the user and don't fail silently. 

## Testing
Create a run while on the crosslinking branch and create some steps that are not on dev (e.g. the multimer importing step). Next, switch the branch to `311-fix-run-deletion`. Here, try to delete the run. Reload and it should still be deleted. Create a new run with the same name, it should be a new run and not the old one again. 
To be honest, I am not sure how to test the error messaging because everything works :P 
But of course feel free to stress test and break things.

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
