### PR TITLE
fix: pie chart coloring is now consistent and does not switch with ma…

### DIFF
--- a/backend/protzilla/data_preprocessing/plots.py
+++ b/backend/protzilla/data_preprocessing/plots.py
@@ -39,7 +39,7 @@ def create_pie_plot(
     )
 
     fig.update_layout(title={"text": f"<b>{heading}</b>"})
-    fig.update_traces(hovertemplate="%{label} <br>Amount: %{value}")
+    fig.update_traces(hovertemplate="%{label} <br>Amount: %{value}", sort=False)
     return fig
 
 


### PR DESCRIPTION
…jority

## Description
fixes #144 
Before, the colors of the pie chart switched along with the majority. Blue was always the larger part. Now it stays consistent with the x values. 

## Changes
Mini change: Set sort to False and the values are not sorted by their y values / theirs shares anymore causing the coloring to stay the same as well.

## Testing
Simply create a standard workflow and look at the pie chart in the filter step. Play around with the values so that the share of protein kept goes from majority to minority and you will see that the color stays the same.

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [x] At least one other developer reviewed and approved the changes
