### PR TITLE
fix: matplotlib images are loaded again in the frontend

### DIFF
--- a/backend/main/views.py
+++ b/backend/main/views.py
@@ -820,7 +820,9 @@ def get_png_from_step(request: HttpRequest):
         )
 
     content = output.decode("utf-8")
-    return JsonResponse({"success": True, "message": "OK", "data": content})
+    return JsonResponse(
+        {"success": True, "message": "OK", "data": {"base64image": content}}
+    )
 
 
 def get_current_step_table_data(request):

--- a/frontend/src/components/app/run-screen/run-screen.tsx
+++ b/frontend/src/components/app/run-screen/run-screen.tsx
@@ -204,7 +204,7 @@ export const RunScreen: React.FC = () => {
     (output: StepOutputInfo, response: ApiResponse<Image>) => ({
       title: output.label,
       alt: output.label,
-      data: "data:image/png;base64," + response.data.data,
+      data: "data:image/png;base64," + response.data.base64image,
     }),
     [],
   );

--- a/frontend/src/utils/protzilla-types.ts
+++ b/frontend/src/utils/protzilla-types.ts
@@ -28,7 +28,7 @@ export interface ApiResponse<T> {
 export interface Image {
   title: string;
   alt: string;
-  data: string;
+  base64image: string;
 }
 
 export interface Download {


### PR DESCRIPTION
## Description
fixes #441
Same mistake as https://github.com/cschlaffner/PROTzilla/pull/421
The frontend expected a different response format from views.py for images.


## Testing
Create a workflow like this and see that the image is rendered. Use Reactome_enrichment_enrichr_2022 from enrichment_data for the upload.
<img width="1911" height="941" alt="grafik" src="https://github.com/user-attachments/assets/140c5e03-04de-4343-aa25-9972c485dcf8" />

## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [ ] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
