### PR TITLE
Changes protein coverage plot to include unquantified peptides

### DIFF
--- a/backend/protzilla/constants/colors.py
+++ b/backend/protzilla/constants/colors.py
@@ -13,35 +13,3 @@ PLOT_PRIMARY_COLOR = PLOT_COLOR_SEQUENCE[0]
 
 PLOT_SECONDARY_COLOR = PLOT_COLOR_SEQUENCE[1]
 """Second color in list."""
-
-
-def rgb_to_hex(rgb):
-    # Convert RGB tuples back to hex color strings
-    return f"#{''.join(f'{c:02x}' for c in rgb)}"
-
-
-def interpolate_color(color_a, color_b, t):
-    """
-    Interpolate between two RGB color strings based on a float t between 0 and 1.
-
-    :param color_a: RGB color string in the format "#RRGGBB".
-    :param color_b: RGB color string in the format "#RRGGBB".
-    :param t: A float between 0 and 1 representing the interpolation factor.
-
-    :return: Interpolated color as an RGB string in the format "#RRGGBB".
-    """
-    if not 0 <= t <= 1:
-        raise ValueError("Interpolation factor t must be between 0 and 1")
-
-    # Convert hex color strings to RGB tuples
-    def hex_to_rgb(hex_color):
-        hex_color = hex_color.lstrip("#")
-        return tuple(int(hex_color[i : i + 2], 16) for i in (0, 2, 4))
-
-    rgb_a = hex_to_rgb(color_a)
-    rgb_b = hex_to_rgb(color_b)
-
-    # Interpolate each color channel
-    interpolated_rgb = tuple(int(a + (b - a) * t) for a, b in zip(rgb_a, rgb_b))
-
-    return rgb_to_hex(interpolated_rgb)

--- a/backend/protzilla/data_analysis/protein_coverage.py
+++ b/backend/protzilla/data_analysis/protein_coverage.py
@@ -302,7 +302,7 @@ def build_coverage_plot(
         )
 
         # Peptide plot
-        # Checking for -inf because these are the result of lof-transforming 0 intensities, i.e., peptides that were
+        # Checking for -inf because these are the result of log-transforming 0 intensities, i.e., peptides that were
         # identified but not quantified. We want to plot them but assign them a default color as not to distort the
         # color scale for actual intensity values.
         current_group_intensities = [

--- a/backend/protzilla/data_analysis/protein_coverage.py
+++ b/backend/protzilla/data_analysis/protein_coverage.py
@@ -1,19 +1,16 @@
+import numpy as np
+import pandas as pd
+import plotly.colors
+import plotly.graph_objects as go
 from dataclasses import dataclass
 from enum import StrEnum
-
-import pandas as pd
-import plotly.graph_objects as go
 from numpy import log2
 from tqdm import tqdm
 
-from backend.protzilla.constants.colors import (
-    PLOT_PRIMARY_COLOR,
-    PLOT_COLOR_SEQUENCE,
-    interpolate_color,
-)
+from backend.protzilla.constants.colors import PLOT_PRIMARY_COLOR
 from backend.protzilla.utilities.utilities import default_intensity_column
 
-INTENSITY_COLORS = ["#FFFFFF", PLOT_COLOR_SEQUENCE[3]]
+INTENSITY_COLOR_SCALE = plotly.colors.sequential.Cividis
 SEQUENCE_DEPTH_PEPTIDE_SPACING = 1
 
 
@@ -169,9 +166,9 @@ def plot_protein_coverage(
     # add group information to the peptide dataframe
     peptide_df = peptide_df.merge(metadata_df, on="Sample")
 
-    reduced_peptide_df = peptide_df[
-        peptide_df[grouping].isin(selected_groups) & peptide_df["Intensity"] > 0
-    ]
+    reduced_peptide_df = peptide_df[peptide_df[grouping].isin(selected_groups)].fillna(
+        0
+    )
     if len(reduced_peptide_df) == 0:
         raise ValueError("No peptides found for the samples provided.")
 
@@ -305,14 +302,21 @@ def build_coverage_plot(
         )
 
         # Peptide plot
+        # Checking for -inf because these are the result of lof-transforming 0 intensities, i.e., peptides that were
+        # identified but not quantified. We want to plot them but assign them a default color as not to distort the
+        # color scale for actual intensity values.
         current_group_intensities = [
-            peptide_match.intensity for row in peptide_rows for peptide_match in row
+            peptide_match.intensity
+            for row in peptide_rows
+            for peptide_match in row
+            if peptide_match.intensity > -np.inf
         ]
-        max_intensity, min_intensity = max(current_group_intensities), min(
-            current_group_intensities
-        )
+        max_intensity = max(current_group_intensities)
+        min_intensity = min(current_group_intensities)
 
         def scale_intensity(intensity):
+            if intensity == -np.inf:
+                return np.nan
             if max_intensity != min_intensity:
                 return (intensity - min_intensity) / (max_intensity - min_intensity)
             return 0
@@ -327,8 +331,6 @@ def build_coverage_plot(
                     row_index=row_index,
                     offset=max_coverage_value + SEQUENCE_DEPTH_PEPTIDE_SPACING,
                     box_height=peptide_box_height,
-                    color_a=INTENSITY_COLORS[0],
-                    color_b=INTENSITY_COLORS[1],
                     grouping=grouping,
                 )
 
@@ -365,18 +367,17 @@ def add_intensity_legend(
     :param fig: The plotly figure to add the legend to
     :param aggregation_method: The method used to aggregate peptide intensities
     """
-    color_scale = [[0, INTENSITY_COLORS[0]], [1, INTENSITY_COLORS[1]]]
     color_legend_trace = go.Scatter(
         x=[None],
         y=[None],
         mode="markers",
         marker={
-            "colorscale": color_scale,
+            "colorscale": INTENSITY_COLOR_SCALE,
             "showscale": True,
             "cmin": 0,
             "cmax": 1,
             "colorbar": {
-                "title": f"Intensity of peptide<br>(aggregated via {aggregation_method})",
+                "title": f"Relative intensity of peptide<br>(aggregated via {aggregation_method})",
                 "x": 1.0,
                 "len": 0.9,
                 "thickness": 30,
@@ -420,8 +421,6 @@ def add_peptide_to_plot(
     row_index: int,
     offset: int,
     box_height: float,
-    color_a: str = "#FFFFFF",
-    color_b: str = PLOT_COLOR_SEQUENCE[3],
     grouping: str = "",
 ) -> None:
     """
@@ -444,7 +443,11 @@ def add_peptide_to_plot(
     )
     y0, y1 = row_index * box_height + offset, (row_index + 1) * box_height + offset
     # interpolate between the two colors
-    color = interpolate_color(color_a, color_b, normalized_intensity)
+    color = (
+        plotly.colors.sample_colorscale(INTENSITY_COLOR_SCALE, normalized_intensity)[0]
+        if not np.isnan(normalized_intensity)
+        else "#CCCCCC"
+    )
     peptide_shape = {
         "type": "rect",
         "x0": x0 - 0.5,
@@ -467,7 +470,7 @@ def add_peptide_to_plot(
             text=[
                 f"{grouping}: {peptide_match.metadata_group}<br>Peptide: {peptide_match.peptide_sequence}<br>"
                 f"({peptide_match.start_location_on_protein}-{peptide_match.end_location_on_protein})<br>"
-                f"Intensity: {peptide_match.intensity}"
+                f"Log2 Intensity: {peptide_match.intensity}"
             ]
             * len(peptide_match.peptide_sequence),
             mode="markers",


### PR DESCRIPTION
## Description

Extends/fixes protein coverage plot so that all identified peptides are plotted even if they have no associated intensity. The coloring was adapted accordingly so that 0 intensities get a gray color and all other intensities follow a colorful colorscale. (Plus some minor label changes)

## Testing

Run for testing: [protein_coverage.zip](https://github.com/user-attachments/files/28395401/protein_coverage.zip)
(Maybe have to reselect both groups in the coverage step because Multiselect tends to "forget" them)

## PR checklist
**Development**
- [X] If necessary, I have updated the documentation (README, docstrings, etc.)
- [X] If necessary, I have created / updated tests.
 
**Mergeability**
- [X] main-branch has been merged into local branch to resolve conflicts
- [X] The tests and linter have passed AFTER local merge
- [X] The backend code has been formatted with `black`
- [X] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [X] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
