### PR TITLE
Add option to upload semicolon separated csv files in metadata import step

### DIFF
--- a/backend/protzilla/constants/option_types.py
+++ b/backend/protzilla/constants/option_types.py
@@ -60,6 +60,12 @@ class PValueColumnName(StrEnum):
     ptm = "PTM"
 
 
+class Separators(StrEnum):
+    comma = "comma"
+    semicolon = "semicolon"
+    tab = "tab"
+
+
 FC_SIGNIFICANCE_COLUMNS = ["Protein ID", "fc_z_score", "fc_significance"]
 CORRECTED_P_VALUES_COLUMNS = [
     "Protein ID",

--- a/backend/protzilla/importing/example_dataset_import.py
+++ b/backend/protzilla/importing/example_dataset_import.py
@@ -86,6 +86,7 @@ def example_dataset_import(import_peptide_data: bool = False) -> dict:
     metadata_import_dict = metadata_import_method(
         file_path=EXAMPLE_DATASET_METADATA_FILE,
         feature_orientation=FeatureOrientationType.COLUMNS.value,
+        comma_separated=True,
     )
     if DataKey.METADATA_DF not in metadata_import_dict:
         return metadata_import_dict

--- a/backend/protzilla/importing/example_dataset_import.py
+++ b/backend/protzilla/importing/example_dataset_import.py
@@ -2,6 +2,7 @@ import py7zr
 from pridepy import pridepy
 
 from backend.protzilla.constants.data_types import DataKey
+from backend.protzilla.constants.option_types import Separators
 from backend.protzilla.constants.intensity_types import IntensityType
 from backend.protzilla.constants.paths import (
     EXAMPLE_DATASET_PROTEIN_FILE,
@@ -86,7 +87,7 @@ def example_dataset_import(import_peptide_data: bool = False) -> dict:
     metadata_import_dict = metadata_import_method(
         file_path=EXAMPLE_DATASET_METADATA_FILE,
         feature_orientation=FeatureOrientationType.COLUMNS.value,
-        comma_separated=True,
+        separator=Separators.comma.value,
     )
     if DataKey.METADATA_DF not in metadata_import_dict:
         return metadata_import_dict

--- a/backend/protzilla/importing/metadata_import.py
+++ b/backend/protzilla/importing/metadata_import.py
@@ -6,20 +6,31 @@ import pandas as pd
 
 from backend.protzilla.constants.paths import BACKEND_PATH
 from backend.protzilla.utilities.utilities import random_string
+from backend.protzilla.constants.option_types import Separators
 
 
 def file_importer(
-    file_path: Path, comma_separated: bool = True
+    file_path: Path,
+    separator: str,
 ) -> tuple[pd.DataFrame, str]:
     """
     Imports a file based on its file extension and returns a pandas DataFrame or None if the file format is not
     supported / the file doesn't exist.
     """
     try:
+        match separator:
+            case Separators.comma.value:
+                sep = ","
+            case Separators.semicolon.value:
+                sep = ";"
+            case Separators.tab.value:
+                sep = "\t"
+            case _:
+                sep = ","
         if file_path.suffix == ".csv":
             meta_df = pd.read_csv(
                 file_path,
-                sep="," if comma_separated else ";",
+                sep=sep,
                 low_memory=False,
                 na_values=[""],
                 keep_default_na=True,
@@ -55,7 +66,7 @@ def file_importer(
 
 
 def metadata_import_method(
-    file_path: Path, feature_orientation: str, comma_separated: bool
+    file_path: Path, feature_orientation: str, separator: str
 ) -> dict:
     """
         Imports a metadata file and returns the intensity dataframe and a dict with a message if the file import failed,
@@ -64,7 +75,7 @@ def metadata_import_method(
     returns: dict of DataFrame and other dict of metadata and messages
     """
     messages = []
-    meta_df, msg = file_importer(file_path, comma_separated)
+    meta_df, msg = file_importer(file_path, separator)
     if meta_df.empty:
         return dict(
             messages=[dict(level=logging.ERROR, msg=msg)],
@@ -107,9 +118,7 @@ def metadata_import_method(
             BACKEND_PATH / f"protzilla/importing/conversion_tmp_{random_string()}.csv"
         )
         meta_df.to_csv(file_path, index=False)
-        return metadata_import_method(
-            file_path, "Columns", comma_separated=comma_separated
-        )
+        return metadata_import_method(file_path, "Columns", separator == separator)
 
     elif str(file_path).startswith(
         f"{BACKEND_PATH}/protzilla/importing/conversion_tmp_"

--- a/backend/protzilla/importing/metadata_import.py
+++ b/backend/protzilla/importing/metadata_import.py
@@ -8,7 +8,9 @@ from backend.protzilla.constants.paths import BACKEND_PATH
 from backend.protzilla.utilities.utilities import random_string
 
 
-def file_importer(file_path: Path) -> tuple[pd.DataFrame, str]:
+def file_importer(
+    file_path: Path, comma_separated: bool = True
+) -> tuple[pd.DataFrame, str]:
     """
     Imports a file based on its file extension and returns a pandas DataFrame or None if the file format is not
     supported / the file doesn't exist.
@@ -17,7 +19,7 @@ def file_importer(file_path: Path) -> tuple[pd.DataFrame, str]:
         if file_path.suffix == ".csv":
             meta_df = pd.read_csv(
                 file_path,
-                sep=",",
+                sep="," if comma_separated else ";",
                 low_memory=False,
                 na_values=[""],
                 keep_default_na=True,
@@ -52,7 +54,9 @@ def file_importer(file_path: Path) -> tuple[pd.DataFrame, str]:
         return pd.DataFrame(), msg
 
 
-def metadata_import_method(file_path: Path, feature_orientation: str) -> dict:
+def metadata_import_method(
+    file_path: Path, feature_orientation: str, comma_separated: bool
+) -> dict:
     """
         Imports a metadata file and returns the intensity dataframe and a dict with a message if the file import failed,
         and the metadata dataframe if the import was successful.
@@ -60,7 +64,7 @@ def metadata_import_method(file_path: Path, feature_orientation: str) -> dict:
     returns: dict of DataFrame and other dict of metadata and messages
     """
     messages = []
-    meta_df, msg = file_importer(file_path)
+    meta_df, msg = file_importer(file_path, comma_separated)
     if meta_df.empty:
         return dict(
             messages=[dict(level=logging.ERROR, msg=msg)],

--- a/backend/protzilla/importing/metadata_import.py
+++ b/backend/protzilla/importing/metadata_import.py
@@ -107,7 +107,9 @@ def metadata_import_method(
             BACKEND_PATH / f"protzilla/importing/conversion_tmp_{random_string()}.csv"
         )
         meta_df.to_csv(file_path, index=False)
-        return metadata_import_method(file_path, "Columns")
+        return metadata_import_method(
+            file_path, "Columns", comma_separated=comma_separated
+        )
 
     elif str(file_path).startswith(
         f"{BACKEND_PATH}/protzilla/importing/conversion_tmp_"

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -3,6 +3,7 @@ from abc import ABC
 from typing_extensions import override
 
 from backend.protzilla.constants.data_types import DataKey
+from backend.protzilla.constants.option_types import Separators
 from backend.protzilla.form import (
     CheckboxField,
     DropdownField,
@@ -219,9 +220,10 @@ class MetadataImport(MetadataImportingStep):
                     value=FeatureOrientationType.COLUMNS.value,
                 ),
                 DropdownField(
-                    name="DropdownField",
+                    name="separator",
                     label="Separator",
-                    value=True,
+                    options=Separators,
+                    value=Separators.comma.value,
                 ),
             ],
         )

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -218,9 +218,9 @@ class MetadataImport(MetadataImportingStep):
                     options=FeatureOrientationType,
                     value=FeatureOrientationType.COLUMNS.value,
                 ),
-                CheckboxField(
-                    name="comma_separated",
-                    label="Uploaded CSV is comma-separated (unselect if semicolon-separated)",
+                DropdownField(
+                    name="DropdownField",
+                    label="Separator",
                     value=True,
                 ),
             ],

--- a/backend/protzilla/methods/importing.py
+++ b/backend/protzilla/methods/importing.py
@@ -218,6 +218,11 @@ class MetadataImport(MetadataImportingStep):
                     options=FeatureOrientationType,
                     value=FeatureOrientationType.COLUMNS.value,
                 ),
+                CheckboxField(
+                    name="comma_separated",
+                    label="Uploaded CSV is comma-separated (unselect if semicolon-separated)",
+                    value=True,
+                ),
             ],
         )
 

--- a/backend/tests/protzilla/data_analysis/ptm_visualization/ptm_vis_test_utils.py
+++ b/backend/tests/protzilla/data_analysis/ptm_visualization/ptm_vis_test_utils.py
@@ -8,6 +8,7 @@ from _pytest.monkeypatch import MonkeyPatch
 
 from backend.main.views_helper import load_settings_from_file
 from backend.protzilla.constants.intensity_types import IntensityType
+from backend.protzilla.constants.option_types import Separators
 from backend.protzilla.constants.paths import SETTINGS_PATH
 from backend.protzilla.data_analysis.ptm_visualization import ptm_vis_utils
 from backend.protzilla.data_analysis.ptm_visualization.ptm_bar_plot import (
@@ -40,7 +41,9 @@ def get_evidence_df(path: Path):
 
 def get_metadata_df(path: Path):
     metadata_df = metadata_import_method(
-        file_path=path, feature_orientation="columns", comma_separated=True
+        file_path=path,
+        feature_orientation="columns",
+        separator=Separators.comma.value,
     )["metadata_df"]
     return metadata_df
 

--- a/backend/tests/protzilla/data_analysis/ptm_visualization/ptm_vis_test_utils.py
+++ b/backend/tests/protzilla/data_analysis/ptm_visualization/ptm_vis_test_utils.py
@@ -39,9 +39,9 @@ def get_evidence_df(path: Path):
 
 
 def get_metadata_df(path: Path):
-    metadata_df = metadata_import_method(file_path=path, feature_orientation="columns")[
-        "metadata_df"
-    ]
+    metadata_df = metadata_import_method(
+        file_path=path, feature_orientation="columns", comma_separated=True
+    )["metadata_df"]
     return metadata_df
 
 

--- a/backend/tests/protzilla/data_analysis/test_ptm_quantification.py
+++ b/backend/tests/protzilla/data_analysis/test_ptm_quantification.py
@@ -83,6 +83,7 @@ def metadata_df():
     df = metadata_import_method(
         TEST_DATA_PATH / "import_data/metadata/metadata_AD01_CTR01.csv",
         feature_orientation="Columns",
+        comma_separated=True,
     )[DataKey.METADATA_DF]
 
     return df

--- a/backend/tests/protzilla/data_analysis/test_ptm_quantification.py
+++ b/backend/tests/protzilla/data_analysis/test_ptm_quantification.py
@@ -1,3 +1,5 @@
+from tkinter.ttk import Separator
+
 import pandas as pd
 import pytest
 from statsmodels.compat.pandas import assert_frame_equal
@@ -14,6 +16,7 @@ from backend.protzilla.importing.metadata_import import metadata_import_method
 from backend.protzilla.importing.peptide_import import peptide_import
 from backend.tests.paths import TEST_DATA_PATH, TEST_PEPTIDES_PATH
 from backend.protzilla.constants.intensity_types import IntensityType
+from backend.protzilla.constants.option_types import Separators
 
 
 @pytest.fixture(scope="module")
@@ -83,7 +86,7 @@ def metadata_df():
     df = metadata_import_method(
         TEST_DATA_PATH / "import_data/metadata/metadata_AD01_CTR01.csv",
         feature_orientation="Columns",
-        comma_separated=True,
+        separator=Separators.comma.value,
     )[DataKey.METADATA_DF]
 
     return df

--- a/backend/tests/protzilla/importing/test_metadata_import.py
+++ b/backend/tests/protzilla/importing/test_metadata_import.py
@@ -27,6 +27,7 @@ def test_metadata_import(run_imported):
         {
             "file_path": TEST_METADATA_PATH / "metadata_cut_columns.csv",
             "feature_orientation": "Columns (samples in rows, features in columns)",
+            "comma_separated": True,
         }
     )
     run_imported.step_calculate()
@@ -51,6 +52,7 @@ def test_metadata_import_faulty_file(run_imported):
         {
             "file_path": TEST_METADATA_PATH / "metadata_sample_column_missing.csv",
             "feature_orientation": "Columns (samples in rows, features in columns)",
+            "comma_separated": True,
         }
     )
     run_imported.step_calculate()
@@ -114,6 +116,7 @@ def test_metadata_orientation(run_imported: Run):
         {
             "file_path": f"{TEST_METADATA_PATH}/metadata_cut_columns.csv",
             "feature_orientation": "Columns (samples in rows, features in columns)",
+            "comma_separated": True,
         }
     )
     run_imported.step_calculate()
@@ -122,6 +125,7 @@ def test_metadata_orientation(run_imported: Run):
         {
             "file_path": f"{TEST_METADATA_PATH}/metadata_cut_rows.csv",
             "feature_orientation": "Rows (samples in columns, features in rows)",
+            "comma_separated": True,
         }
     )
     run_imported.step_calculate()
@@ -139,6 +143,7 @@ def test_metadata_column_assignment(run_empty):
         {
             "file_path": f"{TEST_METADATA_PATH}/metadata_cut_columns.csv",
             "feature_orientation": "Columns (samples in rows, features in columns)",
+            "comma_separated": True,
         }
     )
     run_empty.step_calculate()

--- a/backend/tests/protzilla/importing/test_metadata_import.py
+++ b/backend/tests/protzilla/importing/test_metadata_import.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 
 from backend.protzilla.constants.data_types import DataKey
+from backend.protzilla.constants.option_types import Separators
 from backend.protzilla.run import Run
 from backend.tests.paths import TEST_METADATA_PATH
 from backend.protzilla.methods.importing import (
@@ -27,7 +28,7 @@ def test_metadata_import(run_imported):
         {
             "file_path": TEST_METADATA_PATH / "metadata_cut_columns.csv",
             "feature_orientation": "Columns (samples in rows, features in columns)",
-            "comma_separated": True,
+            "separator": Separators.comma.value,
         }
     )
     run_imported.step_calculate()
@@ -52,7 +53,7 @@ def test_metadata_import_faulty_file(run_imported):
         {
             "file_path": TEST_METADATA_PATH / "metadata_sample_column_missing.csv",
             "feature_orientation": "Columns (samples in rows, features in columns)",
-            "comma_separated": True,
+            "separator": Separators.comma.value,
         }
     )
     run_imported.step_calculate()
@@ -116,7 +117,7 @@ def test_metadata_orientation(run_imported: Run):
         {
             "file_path": f"{TEST_METADATA_PATH}/metadata_cut_columns.csv",
             "feature_orientation": "Columns (samples in rows, features in columns)",
-            "comma_separated": True,
+            "separator": Separators.comma.value,
         }
     )
     run_imported.step_calculate()
@@ -125,7 +126,7 @@ def test_metadata_orientation(run_imported: Run):
         {
             "file_path": f"{TEST_METADATA_PATH}/metadata_cut_rows.csv",
             "feature_orientation": "Rows (samples in columns, features in rows)",
-            "comma_separated": True,
+            "separator": Separators.comma.value,
         }
     )
     run_imported.step_calculate()
@@ -143,7 +144,7 @@ def test_metadata_column_assignment(run_empty):
         {
             "file_path": f"{TEST_METADATA_PATH}/metadata_cut_columns.csv",
             "feature_orientation": "Columns (samples in rows, features in columns)",
-            "comma_separated": True,
+            "separator": Separators.comma.value,
         }
     )
     run_empty.step_calculate()

--- a/backend/tests/protzilla/test_runner.py
+++ b/backend/tests/protzilla/test_runner.py
@@ -236,6 +236,7 @@ def test_runner_imports(
         {
             "file_path": (settings.FILE_UPLOAD_TEMP_DIR / metadata_file_path),
             "feature_orientation": "Columns (samples in rows, features in columns)",
+            "comma_separated": True,
         },
         {"percentage": 0.5, "graph_type": "Pie chart"},
         {"deviation_threshold": 2.0, "graph_type": "Pie chart"},
@@ -371,6 +372,7 @@ def test_runner_calculates(
         {
             "file_path": (settings.FILE_UPLOAD_TEMP_DIR / metadata_file_path),
             "feature_orientation": "Columns (samples in rows, features in columns)",
+            "comma_separated": True,
         },
         {"percentage": 0.5, "graph_type": "Bar chart"},
     ]

--- a/backend/tests/protzilla/test_runner.py
+++ b/backend/tests/protzilla/test_runner.py
@@ -3,6 +3,8 @@ import shutil
 from pathlib import Path
 from unittest import mock
 
+from PIL.ImageShow import im
+
 import pytest
 import yaml
 
@@ -17,6 +19,7 @@ from backend.tests.paths import (
 from backend.protzilla import disk_operator
 from backend.protzilla.runner import Runner
 from runner_cli import args_parser
+from backend.protzilla.constants.option_types import Separators
 
 
 @pytest.fixture
@@ -236,7 +239,7 @@ def test_runner_imports(
         {
             "file_path": (settings.FILE_UPLOAD_TEMP_DIR / metadata_file_path),
             "feature_orientation": "Columns (samples in rows, features in columns)",
-            "comma_separated": True,
+            "separator": Separators.comma.value,
         },
         {"percentage": 0.5, "graph_type": "Pie chart"},
         {"deviation_threshold": 2.0, "graph_type": "Pie chart"},
@@ -372,7 +375,7 @@ def test_runner_calculates(
         {
             "file_path": (settings.FILE_UPLOAD_TEMP_DIR / metadata_file_path),
             "feature_orientation": "Columns (samples in rows, features in columns)",
-            "comma_separated": True,
+            "separator": Separators.comma.value,
         },
         {"percentage": 0.5, "graph_type": "Bar chart"},
     ]

--- a/backend/tests/test_data/workflows/example_workflow.json
+++ b/backend/tests/test_data/workflows/example_workflow.json
@@ -15,7 +15,7 @@
           "method": "metadata_import_method",
           "parameters": {
             "feature_orientation": "Rows (features in rows, samples in columns)",
-            "comma_separated": true
+            "separator": "comma"
           }
         }
       ]

--- a/backend/tests/test_data/workflows/example_workflow.json
+++ b/backend/tests/test_data/workflows/example_workflow.json
@@ -14,7 +14,8 @@
           "name": "metadata_import",
           "method": "metadata_import_method",
           "parameters": {
-            "feature_orientation": "Rows (features in rows, samples in columns)"
+            "feature_orientation": "Rows (features in rows, samples in columns)",
+            "comma_separated": true
           }
         }
       ]


### PR DESCRIPTION
## Description
fixes #450 
We now have a checkbox that the user has to unselect to upload a semicolon separated csv. 

## Changes
Changed the file import and the form for the metadata upload.

## Testing
Create a standard workflow and upload the semicolon separated csv which you can find in the [nextcloud](https://nextcloud.hpi.de/apps/files/files/42343227?dir=/PROTzilla_2025/450-semicolon-separated-csv ).
Of course, make sure to unselect the comma separated checkbox.

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
