### PR TITLE
Fix path serialization in form request

### DIFF
--- a/backend/protzilla/form.py
+++ b/backend/protzilla/form.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import PurePath
+
 from collections.abc import Sequence
 import json
 from dataclasses import asdict, dataclass, field, is_dataclass
@@ -295,7 +297,7 @@ class Form:
         return values
 
     class CustomEncoder(json.JSONEncoder):
-        "Custom JSON encoder that handles Enum classes and functions"
+        "Custom JSON encoder that handles Enum classes, paths and functions"
 
         def default(self, obj):
             # serialize functions
@@ -312,5 +314,8 @@ class Form:
             # Serialize Enum class as dict
             if type(obj) == type(Enum):
                 return [Option(item.name, item.value) for item in obj]
+
+            if isinstance(obj, PurePath):
+                return obj.name
 
             return super().default(obj)

--- a/backend/protzilla/form.py
+++ b/backend/protzilla/form.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     pass
 
 
-FormInputType = str | int | float | bool | list[str]
+FormInputType = str | int | float | bool | None | list[str] | PurePath | Enum
 
 # Backwards compatibility for older imports that expect `inputs` from this module.
 inputs = FormInputType
@@ -154,7 +154,7 @@ class MultiSelectWithDropdownsField(_baseField):
 
 @dataclass
 class FileInput(_baseField):
-    value: str | None = None
+    value: PurePath | None = None
     type: str = "file"
     filedata: str = ""
     accept: str | None = None

--- a/backend/tests/protzilla/test_form.py
+++ b/backend/tests/protzilla/test_form.py
@@ -1,0 +1,123 @@
+"""
+Guards against form fields whose values cannot be serialized by CustomEncoder whenever get_step_form is called.
+"""
+
+from dataclasses import dataclass
+
+from datetime import datetime
+from pathlib import PurePath, PurePosixPath
+
+import collections.abc
+import json
+import pytest
+import types
+import typing
+from enum import Enum
+
+from backend.protzilla.form import (
+    DropdownField,
+    FileInput,
+    Form,
+    Option,
+    RadioSelectField,
+    _baseField,
+)
+
+# These are the types that need to be serialized by CustomEncoder when get_step_form is called. If this set is extended,
+# make sure that CustomEncoder can handle it as well.
+ALLOWED_LEAVES = {str, int, float, bool, type(None), list, PurePath}
+
+
+def all_field_classes(root=_baseField):
+    """Recursively collect every loaded subclass of ``_baseField``."""
+    seen = set()
+    stack = [root]
+    while stack:
+        for sub in stack.pop().__subclasses__():
+            if sub not in seen:
+                seen.add(sub)
+                stack.append(sub)
+    return seen
+
+
+def leaf_types(annotation) -> set:
+    """Flatten an annotation (unions, generics) into its set of leaf types."""
+    origin = typing.get_origin(annotation)
+    if origin in (typing.Union, types.UnionType):  # e.g. str | None
+        return set().union(*(leaf_types(a) for a in typing.get_args(annotation)))
+    if origin in (list, collections.abc.Sequence):  # e.g. list[str]
+        leaves = {list}
+        for arg in typing.get_args(annotation):
+            leaves.update(leaf_types(arg))
+        return leaves
+    if origin is not None:  # any other parameterized generic
+        return {origin}
+    # Is a primitive or non-generic class (e.g. str, PurePath)
+    return {annotation}
+
+
+@pytest.mark.parametrize("field_cls", all_field_classes(), ids=lambda c: c.__name__)
+def test_field_value_types_are_serializable(field_cls):
+    # get_type_hints resolves the string annotations produced by `from __future__ import annotations` in form.py, using
+    # the module globals where PurePath/Enum/etc. are imported.
+    hints = typing.get_type_hints(field_cls)
+    assert "value" in hints, f"{field_cls.__name__} has no 'value' annotation"
+
+    unknown = leaf_types(hints["value"]) - ALLOWED_LEAVES
+    assert not unknown, (
+        f"{field_cls.__name__}.value may contain {unknown}, which the form's CustomEncoder does not handle. Either "
+        "add encoder support and extend ALLOWED_LEAVES, or change the field's value type."
+    )
+
+
+@dataclass
+class MockDateTimeField:
+    name: str
+    label: str
+    type: str = "datetime"
+    value: datetime = datetime.now()
+    isVisible: bool = True
+
+
+def test_datetime_field_fails_encoding():
+    field = MockDateTimeField(name="field", label="Field")
+    assert type(field.value) not in ALLOWED_LEAVES
+    with pytest.raises(TypeError, match="is not JSON serializable"):
+        json.dumps(field, cls=Form.CustomEncoder)
+
+
+@pytest.mark.parametrize("field_cls", all_field_classes(), ids=lambda c: c.__name__)
+def test_default_fields_round_trip_through_encoder(field_cls):
+    """Every field, built with its defaults, must survive json.dumps."""
+    field = field_cls(name="field", label="Field")
+    json.dumps(field, cls=Form.CustomEncoder)
+
+
+class _SampleEnum(Enum):
+    A = "a"
+    B = "b"
+
+
+def _dumps(field) -> str:
+    return json.dumps(field, cls=Form.CustomEncoder)
+
+
+def test_enum_instance_value_round_trips():
+    field = RadioSelectField(name="f", label="F", value=_SampleEnum.A)
+    assert json.loads(_dumps(field))["value"] == "a"
+
+
+def test_enum_class_as_options_round_trips():
+    field = DropdownField(name="f", label="F", options=_SampleEnum)
+    options = json.loads(_dumps(field))["options"]
+    assert {"value": "A", "label": "a"} in options
+
+
+def test_purepath_value_round_trips():
+    field = FileInput(name="f", label="F", value=PurePosixPath("/tmp/data/x.csv"))
+    assert json.loads(_dumps(field))["value"] == "x.csv"
+
+
+def test_option_dataclass_round_trips():
+    field = DropdownField(name="f", label="F", options=[Option("v", "Label")])
+    assert json.loads(_dumps(field))["options"][0] == {"value": "v", "label": "Label"}

--- a/backend/tests/protzilla/test_runner.py
+++ b/backend/tests/protzilla/test_runner.py
@@ -1,14 +1,15 @@
-import json
-import shutil
 from pathlib import Path
 from unittest import mock
 
-from PIL.ImageShow import im
-
+import json
 import pytest
+import shutil
 import yaml
 
 from backend.main import settings
+from backend.protzilla import disk_operator
+from backend.protzilla.constants.option_types import Separators
+from backend.protzilla.runner import Runner
 from backend.protzilla.runner import _serialize_graphs
 from backend.protzilla.utilities.utilities import random_string
 from backend.tests.paths import (
@@ -16,10 +17,7 @@ from backend.tests.paths import (
     TEST_METADATA_PATH,
     TEST_WORKFLOWS_PATH,
 )
-from backend.protzilla import disk_operator
-from backend.protzilla.runner import Runner
 from runner_cli import args_parser
-from backend.protzilla.constants.option_types import Separators
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

Form fields were not able to properly serialize paths when `get_step_form` was called. The `CustomEncoder` was updated to also include paths. I also added some tests that should fail if future code adds data types to fields that cannot natively be serialized for JSON.

## Testing

Create a workflow that contains a step, which uses a file upload (e.g., PTM Visualization: Bar Plot). After uploading a file, it should be possible to navigate away and back to the step again, which led to an error before.

## PR checklist
**Development**
- [X] If necessary, I have updated the documentation (README, docstrings, etc.)
- [X] If necessary, I have created / updated tests.
 
**Mergeability**
- [X] dev-branch has been merged into local branch to resolve conflicts
- [X] The tests and linter have passed AFTER local merge
- [X] The backend code has been formatted with `black`
- [X] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [X] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
