### PR TITLE
459 bug show allowed deviation fields for cl validation

### DIFF
--- a/backend/protzilla/methods/data_analysis.py
+++ b/backend/protzilla/methods/data_analysis.py
@@ -2420,7 +2420,7 @@ class CrosslinkingValidationWithAngstromStep(DataAnalysisStep):
 
             bounds_visible = (
                 form["validation_criterion"].value
-                == CrosslinkingValidationCriterion.manual_bounds.value
+                == CrosslinkingValidationCriterion.manual_bounds
             )
             form[f"{crosslinker}_upper_accepted_deviation"].isVisible = bounds_visible
             form[f"{crosslinker}_lower_accepted_deviation"].isVisible = bounds_visible

--- a/backend/user_data/workflows/cl_monomer.yaml
+++ b/backend/user_data/workflows/cl_monomer.yaml
@@ -21,6 +21,16 @@ graph_edges:
   - s00005_CrosslinkingValidationWithAngstromDeviation
   - source_handle: amino_acid_sequences_df
     target_handle: amino_acid_sequences_df
+- !!python/tuple
+  - s00004_AlphaFoldPredictionLoad
+  - s00005_CrosslinkingValidationWithAngstromDeviation
+  - source_handle: pae_matrix
+    target_handle: pae_matrix
+- !!python/tuple
+  - s00004_AlphaFoldPredictionLoad
+  - s00005_CrosslinkingValidationWithAngstromDeviation
+  - source_handle: plddt_df
+    target_handle: plddt_df
 id_clock: 5
 steps:
 - calculation_status: incomplete
@@ -50,7 +60,8 @@ steps:
       x: 284.1888049686339
       y: -3.6223900627321264
 - calculation_status: incomplete
-  form_inputs: {}
+  form_inputs:
+    validation_criterion: Manual Bounds (set below)
   instance_identifier: s00005_CrosslinkingValidationWithAngstromDeviation
   messages: []
   output: {}


### PR DESCRIPTION
## Description
Fixes #459 (same issue as #455). 
Also, adds the missing connections in the cl_monomer workflow (#454 )
As soon as you have uploaded some crosslinking data the fields for entering manual bounds are displayed.

## Testing
Create a cl_monomer workflow. Check that the connections look like this:
<img width="495" height="233" alt="grafik" src="https://github.com/user-attachments/assets/3767a6fd-6800-4876-969e-b9e6ae86b247" />
Upload some cl data and check that you can enter an upper and lower bound for the accepted validation as soon as you switch to the validation step.

## PR checklist
**Development**
- [ ] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [ ] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
