### PR TITLE
465 add scaling step

### DIFF
--- a/backend/protzilla/all_steps.py
+++ b/backend/protzilla/all_steps.py
@@ -26,6 +26,7 @@ _forward_mapping: list[Step] = [
     data_preprocessing.OutlierDetectionByLocalOutlierFactor,
     data_preprocessing.OutlierDetectionByIsolationForest,
     data_preprocessing.TransformationLog,
+    data_preprocessing.TransformationScaling,
     data_preprocessing.TransformationInversion,
     data_preprocessing.NormalisationByZScore,
     data_preprocessing.NormalisationByTotalSum,

--- a/backend/protzilla/data_preprocessing/transformation.py
+++ b/backend/protzilla/data_preprocessing/transformation.py
@@ -85,7 +85,7 @@ def by_log(
     return dict(protein_df=transformed_df, peptide_df=transformed_peptide_df)
 
 
-def by_log_plot(
+def transformation_plot(
     protein_df, output_protein_df, graph_type, group_by, show_outliers=True
 ):
     if graph_type == "Boxplot":
@@ -110,3 +110,62 @@ def by_log_plot(
             y_title="Frequency of Protein Intensities",
         )
     return [fig]
+
+
+def transform_df_by_scale(
+    df: pd.DataFrame,
+    min_value: float,
+    max_value: float,
+) -> pd.DataFrame:
+
+    intensity_column_name = default_intensity_column(df)
+    intensity_column = df[intensity_column_name]
+
+    min_old = intensity_column.min()
+    max_old = intensity_column.max()
+
+    if min_old == max_old:
+        raise ValueError(
+            "Global max equals global min; cannot scale a constant dataset."
+        )
+
+    transformed_intensity_column = (
+        (intensity_column - min_old) / (max_old - min_old)
+    ) * (max_value - min_value) + min_value
+
+    df[intensity_column_name] = transformed_intensity_column
+    return df
+
+
+def by_scaling(
+    protein_df: pd.DataFrame,
+    min_value: float,
+    max_value: float,
+    peptide_df: pd.DataFrame | None = None,
+):
+    """
+    This function scales the intensity values of the given dataframe based on the min and max values given.
+    It maps the minimum of the protein intensities to the given minimum value and the maximum to the given maximum.
+    All values in between are scaled accordingly.
+
+    :param protein_df: a protein data frame in long format
+    :param minimum_value: minimum value the transformed data should have
+    :param maximum_value: maximum value the transformed data should have
+    :param peptide_df: a peptide data frame, that is to be transformed the same way as the protein data frame
+
+    :return: returns a dict containing the transformed dataframes for "protein_df" and "peptide_df" respectively
+    :rtype: dict[str, pd.DataFrame | None]
+    """
+    transformed_df = protein_df.copy()
+    transformed_peptide_df = peptide_df.copy() if peptide_df is not None else None
+
+    transformed_df = transform_df_by_scale(
+        df=transformed_df, min_value=min_value, max_value=max_value
+    )
+
+    if transformed_peptide_df is not None:
+        transformed_peptide_df = transform_df_by_scale(
+            df=transformed_peptide_df, min_value=min_value, max_value=max_value
+        )
+
+    return dict(protein_df=transformed_df, peptide_df=transformed_peptide_df)

--- a/backend/protzilla/data_preprocessing/transformation.py
+++ b/backend/protzilla/data_preprocessing/transformation.py
@@ -128,6 +128,10 @@ def transform_df_by_scale(
         raise ValueError(
             "Global max equals global min; cannot scale a constant dataset."
         )
+    elif min_value >= max_value:
+        raise ValueError(
+            "The minimum value given must be lower than the maximum value."
+        )
 
     transformed_intensity_column = (
         (intensity_column - min_old) / (max_old - min_old)

--- a/backend/protzilla/methods/data_preprocessing.py
+++ b/backend/protzilla/methods/data_preprocessing.py
@@ -518,7 +518,59 @@ class TransformationLog(DataPreprocessingStep):
             self.form["show_outliers_info"].isVisible = False
 
     calc_method = staticmethod(transformation.by_log)
-    plot_method = staticmethod(transformation.by_log_plot)
+    plot_method = staticmethod(transformation.transformation_plot)
+
+
+class TransformationScaling(DataPreprocessingStep):
+    display_name = "Transformation: Scaling"
+    operation: StepOperation = StepOperation.TRANSFORMATION
+    method_description = "Transform data by scaling"
+
+    def create_form(self):
+        return Form(
+            label="Scaling Transformation",
+            input_fields=[
+                FloatField(
+                    name="min_value",
+                    label="Minimum value that data minimum should be mapped to",
+                ),
+                FloatField(
+                    name="max_value",
+                    label="Maximum value that data maximum should be mapped to",
+                ),
+                FormDivider("Plot settings"),
+                DropdownField(
+                    name="graph_type",
+                    label="Graph type",
+                    value=BoxAndHistogramGraph.BOXPLOT.value,
+                    options=BoxAndHistogramGraph,
+                ),
+                DropdownField(
+                    name="group_by",
+                    label="Group by",
+                    value=GroupBy.NO_GROUPING.value,
+                    options=GroupBy,
+                ),
+                CheckboxField(
+                    name="show_outliers",
+                    label="Show outliers",
+                    value=True,
+                    isVisible=True,
+                ),
+                info_field_show_outliers,
+            ],
+        )
+
+    def modify_form(self, run):
+        if self.form["graph_type"].value == BoxAndHistogramGraph.BOXPLOT.value:
+            self.form["show_outliers"].isVisible = True
+            self.form["show_outliers_info"].isVisible = True
+        else:
+            self.form["show_outliers"].isVisible = False
+            self.form["show_outliers_info"].isVisible = False
+
+    calc_method = staticmethod(transformation.by_scaling)
+    plot_method = staticmethod(transformation.transformation_plot)
 
 
 class TransformationInversion(DataPreprocessingStep):

--- a/backend/tests/main/test_views_helper.py
+++ b/backend/tests/main/test_views_helper.py
@@ -24,6 +24,7 @@ def test_get_all_possible_step_names():
         "OutlierDetectionByIsolationForest",
         "TransformationLog",
         "TransformationInversion",
+        "TransformationScaling",
         "NormalisationByZScore",
         "NormalisationByTotalSum",
         "NormalisationByMedian",

--- a/backend/tests/protzilla/data_preprocessing/test_transformation.py
+++ b/backend/tests/protzilla/data_preprocessing/test_transformation.py
@@ -6,7 +6,8 @@ from backend.protzilla.constants.data_types import DataKey
 from backend.protzilla.data_preprocessing.transformation import (
     by_inversion,
     by_log,
-    by_log_plot,
+    by_scaling,
+    transformation_plot,
 )
 
 
@@ -253,6 +254,50 @@ def inversion_transformation_expected_peptide_intensities():
     )
 
 
+@pytest.fixture
+def scaling_transformation_df():
+    test_intensity_list = (
+        ["Sample1", "Protein1", "Gene1", 1.0],
+        ["Sample1", "Protein2", "Gene2", 4.0],
+        ["Sample1", "Protein3", "Gene3", np.nan],
+        ["Sample1", "Protein4", "Gene4", 10.0],
+        ["Sample2", "Protein1", "Gene1", 7.0],
+    )
+    return pd.DataFrame(
+        data=test_intensity_list,
+        columns=["Sample", "Protein ID", "Gene", "Intensity"],
+    )
+
+
+@pytest.fixture
+def scaling_transformation_expected_df_0_to_100():
+    test_intensity_list = (
+        ["Sample1", "Protein1", "Gene1", 0.0],
+        ["Sample1", "Protein2", "Gene2", 33.33333333333333],
+        ["Sample1", "Protein3", "Gene3", np.nan],
+        ["Sample1", "Protein4", "Gene4", 100.0],
+        ["Sample2", "Protein1", "Gene1", 66.66666666666666],
+    )
+    return pd.DataFrame(
+        data=test_intensity_list,
+        columns=["Sample", "Protein ID", "Gene", "Intensity"],
+    )
+
+
+@pytest.fixture
+def scaling_transformation_faulty_df():
+    # All non-NaN values are identical (constant dataset)
+    test_intensity_list = (
+        ["Sample1", "Protein1", "Gene1", 5.0],
+        ["Sample1", "Protein2", "Gene2", 5.0],
+        ["Sample1", "Protein3", "Gene3", np.nan],
+    )
+    return pd.DataFrame(
+        data=test_intensity_list,
+        columns=["Sample", "Protein ID", "Gene", "Intensity"],
+    )
+
+
 def test_log2_transformation(
     show_figures,
     log2_transformation_df,
@@ -267,7 +312,7 @@ def test_log2_transformation(
     }
     method_outputs = by_log(**method_inputs)
 
-    fig = by_log_plot(
+    fig = transformation_plot(
         log2_transformation_df,
         method_outputs[DataKey.PROTEIN_DF],
         "Boxplot",
@@ -334,7 +379,7 @@ def test_log10_transformation(
     }
     method_output = by_log(**method_inputs)
 
-    fig = by_log_plot(
+    fig = transformation_plot(
         log10_transformation_df,
         method_output[DataKey.PROTEIN_DF],
         "Boxplot",
@@ -387,3 +432,71 @@ def test_inversion_transformation_div0(inversion_transformation_faulty_df):
         by_inversion(**method_inputs)
 
     assert str(excinfo.value) == "Division by zero when inverting values."
+
+
+def test_by_scaling(
+    scaling_transformation_df,
+    scaling_transformation_expected_df_0_to_100,
+):
+    method_inputs = {
+        "protein_df": scaling_transformation_df,
+        "min_value": 0.0,
+        "max_value": 100.0,
+        "peptide_df": None,
+    }
+
+    method_outputs = by_scaling(**method_inputs)
+    result_df = method_outputs["protein_df"]
+
+    pd.testing.assert_frame_equal(
+        result_df,
+        scaling_transformation_expected_df_0_to_100,
+        check_dtype=False,
+        atol=1e-5,
+    )
+
+
+def test_by_scaling_with_peptides(
+    scaling_transformation_df,
+    scaling_transformation_expected_df_0_to_100,
+):
+    method_inputs = {
+        "protein_df": scaling_transformation_df,
+        "peptide_df": scaling_transformation_df.copy(),
+        "min_value": 0.0,
+        "max_value": 100.0,
+    }
+
+    method_outputs = by_scaling(**method_inputs)
+
+    assert method_outputs["protein_df"] is not None
+    assert method_outputs["peptide_df"] is not None
+
+    pd.testing.assert_frame_equal(
+        method_outputs["protein_df"],
+        scaling_transformation_expected_df_0_to_100,
+        check_dtype=False,
+        atol=1e-5,
+    )
+    pd.testing.assert_frame_equal(
+        method_outputs["peptide_df"],
+        scaling_transformation_expected_df_0_to_100,
+        check_dtype=False,
+        atol=1e-5,
+    )
+
+
+def test_by_scaling_constant_value_error(scaling_transformation_faulty_df):
+    method_inputs = {
+        "protein_df": scaling_transformation_faulty_df,
+        "min_value": 0.0,
+        "max_value": 100.0,
+        "peptide_df": None,
+    }
+
+    with pytest.raises(ValueError) as excinfo:
+        by_scaling(**method_inputs)
+
+    assert "Global max equals global min; cannot scale a constant dataset." in str(
+        excinfo.value
+    )


### PR DESCRIPTION
## Description
fixes #465 
This issue introduces a new step in which the intensity values can be scaled. 

## Changes
Added the new step to transformations in data_preprocessing and added new tests.

## Testing
Create a standard workflow. Add the scaling step (I would assume one would usually want the scaling step after the normalization and log transformation). And check out how the data scales. The min value of the protein df given should map to the minimum value set in the parameters, same with the maximum values.

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [x] If necessary, I have created / updated tests.
 
**Mergeability**
- [x] main-branch has been merged into local branch to resolve conflicts
- [x] The tests and linter have passed AFTER local merge
- [x] The backend code has been formatted with `black`
- [x] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [x] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
