### PR TITLE
fix enrichr organism names

### DIFF
--- a/backend/protzilla/methods/data_integration.py
+++ b/backend/protzilla/methods/data_integration.py
@@ -44,13 +44,12 @@ class Direction(Enum):
 
 
 class Organism(Enum):
-    human = "Human"
-    mouse = "Mouse"
-    rat = "Rat"
-    yeast = "Yeast"
-    fly = "Fly"
-    fish = "Fish"
-    worm = "Worm"
+    human = "human"
+    mouse = "mouse"
+    yeast = "yeast"
+    fly = "fly"
+    fish = "fish"
+    worm = "worm"
 
 
 class PermutationTypeField(Enum):
@@ -300,11 +299,16 @@ class EnrichmentAnalysisGOAnalysisWithEnrichr(EnrichmentAnalysisGOStep):
 
         if gene_sets_field.value == GeneSetsType.choose_from_enrichr_options.value:
             gene_sets_enricher_field.isVisible = True
-            gene_sets_enricher_field.set_options(
-                form_helper.to_choices(
-                    gseapy.get_library_name()
-                )  # TODO check whether we need to pass the organism name here
-            )
+            try:
+                gene_sets_enricher_field.set_options(
+                    form_helper.to_choices(
+                        gseapy.get_library_name()
+                    )  # TODO check whether we need to pass the organism name here
+                )
+            except Exception:
+                gene_sets_enricher_field.set_options(
+                    form_helper.to_choices([])
+                )
         else:
             gene_sets_path_field.isVisible = True
 

--- a/backend/protzilla/methods/data_integration.py
+++ b/backend/protzilla/methods/data_integration.py
@@ -306,9 +306,7 @@ class EnrichmentAnalysisGOAnalysisWithEnrichr(EnrichmentAnalysisGOStep):
                     )  # TODO check whether we need to pass the organism name here
                 )
             except Exception:
-                gene_sets_enricher_field.set_options(
-                    form_helper.to_choices([])
-                )
+                gene_sets_enricher_field.set_options(form_helper.to_choices([]))
         else:
             gene_sets_path_field.isVisible = True
 


### PR DESCRIPTION
## Description
fixes #468
Fixes the organism names for upstream enrichr

## Changes
Lowercase :+1: 

## Testing
Use any protein_df that comes from a t_test where we have a log2_foldchange column (e.g. significant_proteins_df). Perform a Gene Mapping step using the integrated uniprot DB on that df and connect the output and the protein df to GO Analysis (Enrichr API). Set the column to log2_fold_change and the threshold to 0, then check with different organisms and see that the enrichment does not crash because the organism id is invalid.

## PR checklist
**Development**
- [x] If necessary, I have updated the documentation (README, docstrings, etc.)
- [ ] If necessary, I have created / updated tests.
 
**Mergeability**
- [ ] main-branch has been merged into local branch to resolve conflicts
- [ ] The tests and linter have passed AFTER local merge
- [ ] The backend code has been formatted with `black`
- [ ] The frontend code has been formatted with `pnpm format` and checked with `pnpm lint`
 
**Code review**
- [ ] I have self-reviewed my code.
- [ ] At least one other developer reviewed and approved the changes
